### PR TITLE
Add os_name environment marker for platform-dependent pypi dependencies

### DIFF
--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -71,12 +71,15 @@ class PlatformEnv(Env):
         if platform.startswith("osx-"):
             self._sys_platform = "darwin"
             self._platform_system = "Darwin"
+            self._os_name = "posix"
         elif platform.startswith("linux-"):
             self._sys_platform = "linux"
             self._platform_system = "Linux"
+            self._os_name = "posix"
         elif platform.startswith("win-"):
             self._sys_platform = "win32"
             self._platform_system = "Windows"
+            self._os_name = "nt"
         else:
             raise ValueError(f"Unsupported platform '{platform}'")
 
@@ -99,6 +102,7 @@ class PlatformEnv(Env):
             "python_version": ".".join([str(c) for c in self._python_version[:2]]),
             "sys_platform": self._sys_platform,
             "platform_system": self._platform_system,
+            "os_name": self._os_name,
         }
 
 

--- a/tests/test-os-name-marker/environment.yml
+++ b/tests/test-os-name-marker/environment.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - pip
+  - pip:
+    - jupyter-server ==2.3.0
+platforms:
+  - linux-64

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -960,6 +960,25 @@ def test_run_lock_with_pip(
     run_lock([pip_environment], conda_exe=conda_exe)
 
 
+@pytest.fixture
+def os_name_marker_environment(tmp_path: Path):
+    return clone_test_dir("test-os-name-marker", tmp_path).joinpath("environment.yml")
+
+
+def test_os_name_marker(
+    monkeypatch: pytest.MonkeyPatch, os_name_marker_environment: Path, conda_exe: str
+):
+    monkeypatch.chdir(os_name_marker_environment.parent)
+    if is_micromamba(conda_exe):
+        monkeypatch.setenv("CONDA_FLAGS", "-v")
+    run_lock([os_name_marker_environment], conda_exe=conda_exe)
+    lockfile = parse_conda_lock_file(
+        os_name_marker_environment.parent / DEFAULT_LOCKFILE_NAME
+    )
+    for package in lockfile.package:
+        assert package.name != "pywinpty"
+
+
 def test_run_lock_with_pip_environment_different_names_same_deps(
     monkeypatch: "pytest.MonkeyPatch",
     pip_environment_different_names_same_deps: Path,


### PR DESCRIPTION
fixes #293

Adds the "os_name" environment marker (https://peps.python.org/pep-0508/#environment-markers) used by some packages to mark platform-specific dependencies, for example [jupyter_server](https://github.com/jupyter-server/jupyter_server/blob/a55bc587e9c343509e95bd93961e27e331882834/pyproject.toml#L40):
```python
requires-python = ">=3.8"
dependencies = [
    "anyio>=3.1.0,<4",
    "pywinpty;os_name=='nt'",
```
