### PR TITLE
Add pyproject.toml option to prevent requests on pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Right now `conda-lock` only supports [legacy](https://warehouse.pypa.io/api-refe
 poetry config repositories.foo https://username:password@foo.repo/simple/
 ```
 
+The private repo will be used in addition to `pypi.org`. For projects using `pyproject.toml`, it is possible to [disable `pypi.org` entirely](#disabling-pypiorg).
+
 ### --dev-dependencies/--no-dev-dependencies
 
 By default conda-lock will include dev dependencies in the specification of the lock (if the files that the lock
@@ -390,6 +392,14 @@ ampel-ztf = {source = "pypi"}
 In both these cases, the dependencies of `pip`-installable packages will also be
 installed with `pip`, unless they were already requested by a `conda`
 dependency.
+
+#### Disabling pypi.org
+
+When using private pip repos, it is possible to disable `pypi.org` entirely. This can be useful when using `conda-lock` behind a network proxy that does not allow access to `pypi.org`.
+```toml
+[tool.conda-lock]
+allow-pypi-requests = false
+```
 
 ## Dockerfile example
 

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -742,6 +742,7 @@ def _solve_for_arch(
             conda_locked={dep.name: dep for dep in conda_deps.values()},
             python_version=conda_deps["python"].version,
             platform=platform,
+            allow_pypi_requests=spec.allow_pypi_requests,
         )
     else:
         pip_deps = {}

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -71,6 +71,7 @@ class LockSpecification(BaseModel):
     platforms: List[str]
     sources: List[pathlib.Path]
     virtual_package_repo: Optional[FakeRepoData] = None
+    allow_pypi_requests: bool = True
 
     def content_hash(self) -> Dict[str, str]:
         return {

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -221,6 +221,9 @@ def specification_with_dependencies(
         channels=get_in(["tool", "conda-lock", "channels"], toml_contents, []),
         platforms=get_in(["tool", "conda-lock", "platforms"], toml_contents, []),
         sources=[path],
+        allow_pypi_requests=get_in(
+            ["tool", "conda-lock", "allow-pypi-requests"], toml_contents, True
+        ),
     )
 
 

--- a/tests/test-poetry-no-pypi/pyproject.toml
+++ b/tests/test-poetry-no-pypi/pyproject.toml
@@ -1,0 +1,30 @@
+[tool.poetry]
+name = "conda-lock-test-poetry"
+version = "0.0.1"
+description = ""
+authors = ["conda-lock"]
+
+[tool.poetry.dependencies]
+requests = "^2.13.0"
+toml = ">=0.10"
+tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }
+
+[tool.poetry.dev-dependencies]
+pytest = "~5.1.0"
+
+[tool.poetry.extras]
+tomlkit = ["tomlkit"]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.conda-lock]
+allow-pypi-requests = false
+channels = [
+    'defaults'
+]
+
+[tool.conda-lock.dependencies]
+sqlite = "<3.34"
+certifi = ">=2019.11.28"


### PR DESCRIPTION
My corporate proxy does not allow access to `pypi.org`. We have a private mirror accessible, but unfortunately `conda-lock` attempts to make requests to `pypi.org` even when the private mirror is set up, resulting in a conda-lock exception.

With this CLI flag, we can ensure that no request goes to `pypi.org`.