### PR TITLE
Configure workflow concurrency for faster feedback and avoid double runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,17 @@ name: test
 on:
   pull_request:
   push:
+    branches:
+      - main
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   test-windows:


### PR DESCRIPTION
### Description

Set `cancel-in-progress: true` so that updates to a PR cancel still running previous workflow runs. This leads to faster CI feedback, because otherwise the builds are all queued up. Also avoiding double builds caused by the push and pull_request events being activated for all branches and thus in PRs trigger two builds for the same thing.

Inspired by https://github.com/conda/conda/blob/main/.github/workflows/tests.yml#L18

Noticed this while preparing a PR (in a repo fork) where multiple updates to a PR led to a long waiting time due the queued up builds and double triggers.





