### PR TITLE
Enable codecov coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,14 @@ jobs:
       - name: run-test
         run: |
           conda activate test
+          copy pyproject.toml "%RUNNER_TEMP%"
           Xcopy /E /I tests "%RUNNER_TEMP%\\tests"
           pushd "${RUNNER_TEMP}"
           set TMPDIR="%RUNNER_TEMP%"
           dir
-          pytest -n auto -vrsx --cov=conda_lock tests
+          pytest tests
+          copy coverage.xml %GITHUB_WORKSPACE%
+      - uses: codecov/codecov-action@v3
 
   test:
     runs-on: ${{ matrix.os }}
@@ -96,13 +99,16 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate test
+          cp pyproject.toml "${RUNNER_TEMP}/"
           cp -a tests "${RUNNER_TEMP}/"
           pushd "${RUNNER_TEMP}"
           export TMPDIR="${RUNNER_TEMP}"
           ls -lah
           set -x
           which pytest
-          pytest -n auto -vrsx --cov=conda_lock tests
+          pytest tests
+          cp coverage.xml "${GITHUB_WORKSPACE}"
+      - uses: codecov/codecov-action@v3
 
       - name: test-gdal
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI](https://img.shields.io/pypi/v/conda-lock?style=for-the-badge)](https://pypi.org/project/conda-lock/)
 [![Conda](https://img.shields.io/conda/v/conda-forge/conda-lock?style=for-the-badge)](https://github.com/conda-forge/conda-lock-feedstock)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=for-the-badge)](https://results.pre-commit.ci/latest/github/conda/conda-lock/main)
+[![codecov](https://img.shields.io/codecov/c/github/conda/conda-lock/main?style=for-the-badge)](https://codecov.io/gh/conda/conda-lock)
 
 Conda lock is a lightweight library that can be used to generate fully reproducible lock files for [conda][conda]
 environments.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch: false
+    project: false
+
+github_checks: false
+
+comment: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ ignore = [
 
 [tool.coverage.run]
 omit = [
-    "conda_lock/vendor/*",
+    "*/conda_lock/_vendor/*",
 ]
 source = [
     "conda_lock/*",
@@ -81,10 +81,10 @@ use_parentheses = true
 known_first_party = "attr"
 
 [tool.pytest.ini_options]
-addopts = "-vrsx -n auto"
+addopts = "-vrsx -n auto --cov=conda_lock --cov-branch --cov-report=xml --cov-report term"
 flake8-max-line-length = 105
 flake8-ignore = ["docs/* ALL", "conda_lock/_version.py ALL"]
-
+filterwarnings = "ignore::DeprecationWarning"
 
 [tool.vendoring]
 destination = "conda_lock/_vendor"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore::DeprecationWarning


### PR DESCRIPTION
Allows to see what is tested (or also what is potentially dead code).

Also:
* Move all pytest settings to pyproject.toml
* Fix `omit` property (=path glob)
* Use settings from pyproject.toml during test runs
* Disable codecov status reporting / comments to PRs (active after merge to main branch).
* Make coverage link available via badge in the README

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
