### PR TITLE
Remove all References of `pip_support` Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ The default category is `main`.
 ### pip support
 
 `conda-lock` can also lock the `dependencies.pip` section of
-[environment.yml][envyaml], using [Poetry's][poetry] dependency solver, if
-installed with the `pip_support` extra.
+[environment.yml][envyaml], using a vendored copy of [Poetry's][poetry] dependency solver.
 
 ### private pip repositories
 Right now `conda-lock` only supports [legacy](https://warehouse.pypa.io/api-reference/legacy.html) pypi repos with basic auth. Most self-hosted repositories like Nexus, Artifactory etc. use this. To use this feature, add your private repo into Poetry's config _including_ the basic auth in the url:

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -53,15 +53,6 @@ from conda_lock.invoke_conda import (
     determine_conda_executable,
     is_micromamba,
 )
-from conda_lock.models.channel import Channel
-
-
-try:
-    from conda_lock.pypi_solver import solve_pypi
-
-    PIP_SUPPORT = True
-except ImportError:
-    PIP_SUPPORT = False
 from conda_lock.lockfile import (
     Dependency,
     GitMeta,
@@ -76,6 +67,8 @@ from conda_lock.lockfile import (
     write_conda_lock_file,
 )
 from conda_lock.lookup import set_lookup_location
+from conda_lock.models.channel import Channel
+from conda_lock.pypi_solver import solve_pypi
 from conda_lock.src_parser import LockSpecification, aggregate_lock_specs
 from conda_lock.src_parser.environment_yaml import parse_environment_file
 from conda_lock.src_parser.meta_yaml import parse_meta_yaml_file
@@ -729,8 +722,6 @@ def _solve_for_arch(
     )
 
     if requested_deps_by_name["pip"]:
-        if not PIP_SUPPORT:
-            raise ValueError("pip support is not enabled")
         if "python" not in conda_deps:
             raise ValueError("Got pip specs without Python")
         pip_deps = solve_pypi(
@@ -896,7 +887,6 @@ def parse_source_files(
                     src_file,
                     platform_overrides,
                     default_platforms=DEFAULT_PLATFORMS,
-                    pip_support=PIP_SUPPORT,
                 )
             )
     return desired_envs

--- a/conda_lock/src_parser/environment_yaml.py
+++ b/conda_lock/src_parser/environment_yaml.py
@@ -115,7 +115,7 @@ def parse_environment_file(
     given_platforms: Optional[Sequence[str]],
     *,
     default_platforms: List[str] = [],
-    pip_support: bool = False,
+    pip_support: bool = True,
 ) -> LockSpecification:
     """Parse a simple environment-yaml file for dependencies assuming the target platforms.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,11 +8,6 @@ conda-lock is available through `pip`, `conda` and `mamba`.
     pip install conda-lock
     ```
 
-    Install with pip support
-    ```sh
-    pip install conda-lock[pip_support]
-    ```
-
 === "conda"
 
     ```sh

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -5,8 +5,7 @@ conda-lock has experimental support to allow locking mixed conda/pip environment
 ## Usage with environment.yaml
 
 `conda-lock` can lock the `dependencies.pip` section of
-[environment.yml](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually), using [Poetry's](https://python-poetry.org) dependency solver, if
-installed with the `pip_support` extra.
+[environment.yml](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually), using a vendored copy of [Poetry's](https://python-poetry.org) dependency solver.
 
 ```{.yaml title="environment.yml"}
 channels:

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -313,7 +313,7 @@ def test_lock_poetry_ibis(
 
 
 def test_parse_environment_file(gdal_environment: Path):
-    res = parse_environment_file(gdal_environment, DEFAULT_PLATFORMS, pip_support=True)
+    res = parse_environment_file(gdal_environment, DEFAULT_PLATFORMS)
     assert all(
         x in res.dependencies
         for x in [
@@ -343,7 +343,7 @@ def test_parse_environment_file(gdal_environment: Path):
 
 
 def test_parse_environment_file_with_pip(pip_environment: Path):
-    res = parse_environment_file(pip_environment, DEFAULT_PLATFORMS, pip_support=True)
+    res = parse_environment_file(pip_environment, DEFAULT_PLATFORMS)
     assert [dep for dep in res.dependencies if dep.manager == "pip"] == [
         VersionedDependency(
             name="requests-toolbelt",
@@ -357,7 +357,7 @@ def test_parse_environment_file_with_pip(pip_environment: Path):
 
 
 def test_parse_env_file_with_filters_no_args(filter_conda_environment: Path):
-    res = parse_environment_file(filter_conda_environment, None, pip_support=False)
+    res = parse_environment_file(filter_conda_environment, None)
     assert all(x in res.platforms for x in ["osx-arm64", "osx-64", "linux-64"])
     assert res.channels == [Channel.from_string("conda-forge")]
 
@@ -392,9 +392,7 @@ def test_parse_env_file_with_filters_no_args(filter_conda_environment: Path):
 
 
 def test_parse_env_file_with_filters_defaults(filter_conda_environment: Path):
-    res = parse_environment_file(
-        filter_conda_environment, DEFAULT_PLATFORMS, pip_support=False
-    )
+    res = parse_environment_file(filter_conda_environment, DEFAULT_PLATFORMS)
     assert all(x in res.platforms for x in DEFAULT_PLATFORMS)
     assert res.channels == [Channel.from_string("conda-forge")]
 


### PR DESCRIPTION
### Description
Closes #339 by removing any references of the `pip_support` extra from the docs and README. It also removes the vacuous use of the PIP_SUPPORT flag and anywhere that flag is passed into, especially in the `conda_lock.src_parser.environment_yaml.py` module.
