### PR TITLE
Have Vendored Poetry Store Config, Cache, and Data Folders in "pypoetry-conda-lock"

### DIFF
--- a/conda_lock/_vendor/poetry/locations.py
+++ b/conda_lock/_vendor/poetry/locations.py
@@ -6,8 +6,8 @@ from .utils.appdirs import user_config_dir
 from .utils.appdirs import user_data_dir
 
 
-CACHE_DIR = user_cache_dir("pypoetry")
-CONFIG_DIR = user_config_dir("pypoetry")
+CACHE_DIR = user_cache_dir("pypoetry-conda-lock")
+CONFIG_DIR = user_config_dir("pypoetry-conda-lock")
 
 REPOSITORY_CACHE_DIR = Path(CACHE_DIR) / "cache" / "repositories"
 
@@ -16,4 +16,4 @@ def data_dir():  # type: () -> Path
     if os.getenv("POETRY_HOME"):
         return Path(os.getenv("POETRY_HOME")).expanduser()
 
-    return Path(user_data_dir("pypoetry", roaming=True))
+    return Path(user_data_dir("pypoetry-conda-lock", roaming=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,5 +107,6 @@ drop = [
 ]
 substitute = [
     # simple substitution patch to fix conda.exports
-    { match = 'conda\.base\.context', replace = 'conda_lock.vendor.conda.base.context' }
+    { match = 'conda\.base\.context', replace = 'conda_lock.vendor.conda.base.context' },
+    { match = '"pypoetry"', replace = '"pypoetry-conda-lock"' }
 ]


### PR DESCRIPTION
### Description
We determined that the problems we noticed in #315 was caused when Poetry is installed on a user's machine and it's cache conflicts with the vendored poetry's cache. By modifying the locations inside of vendored poetry, we can ensure that it
- Stores it cache, config files, and data folder in a different folder from poetry. Poetry stores them in a folder called "pypoetry" and we will in "pypoetry-conda-lock". Note that the location of the folder is OS specific. More details can be found here: https://python-poetry.org/docs/configuration/#default-directories
- Ensure that vendored poetry will not use any config options a user sets for regular poetry

Note that as @maresb suggested in https://github.com/conda/conda-lock/issues/315#issuecomment-1418361666, I added a option to `vendoring` in `pyproject.toml` to replace any instances of `"pypoetry"`, but manually modified the affected file myself since re-vendoring Poetry is not possible right now.