### PR TITLE
[WIP] support poetry sources for private pypi repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,33 @@ The default category is `main`.
 [environment.yml][envyaml], using a vendored copy of [Poetry's][poetry] dependency solver.
 
 ### private pip repositories
-Right now `conda-lock` only supports [legacy](https://warehouse.pypa.io/api-reference/legacy.html) pypi repos with basic auth. Most self-hosted repositories like Nexus, Artifactory etc. use this. To use this feature, add your private repo into Poetry's config _including_ the basic auth in the url:
+
+`conda-lock` currently only supports [legacy](https://warehouse.pypa.io/api-reference/legacy.html) pypi repos with basic auth. Most self-hosted repositories like Nexus, Artifactory etc. use this.
+
+#### pyproject.toml: via poetry sources
+
+conda-lock can fetch packages from (private) python indices using [poetry sources](https://python-poetry.org/docs/repositories/#project-configuration) in the pyproject.toml:
+
+```toml
+[[tool.poetry.source]]
+name = "my_pypi"
+url = "https://pypi.python.org/simple"
+default = false
+secondary = false
+```
+
+You need to manually assign the source to the dependent with the `source` keyword.
+
+```toml
+[tool.poetry.dependencies]
+numpy = {version="*", source="my_pypi"}
+```
+
+Should your source require login credentials you can provide them via poetry commandline: `poetry config http-basic.<source-name> <username> <password>`.
+
+#### private pypi repos without pyproject.toml
+
+For sources other than `pyprojoect.toml` add your private repo into Poetry's config _including_ the basic auth in the url:
 
 ```bash
 poetry config repositories.foo https://username:password@foo.repo/simple/

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -733,6 +733,7 @@ def _solve_for_arch(
             conda_locked={dep.name: dep for dep in conda_deps.values()},
             python_version=conda_deps["python"].version,
             platform=platform,
+            poetry_repositories=spec.poetry_repositories,
             allow_pypi_requests=spec.allow_pypi_requests,
         )
     else:

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -733,7 +733,7 @@ def _solve_for_arch(
             conda_locked={dep.name: dep for dep in conda_deps.values()},
             python_version=conda_deps["python"].version,
             platform=platform,
-            poetry_repositories=spec.poetry_repositories,
+            pypi_channels=spec.pypi_channels,
             allow_pypi_requests=spec.allow_pypi_requests,
         )
     else:

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -143,7 +143,7 @@ def solve_conda(
     """
 
     conda_specs = [
-        _to_match_spec(dep.name, dep.version, dep.build, dep.conda_channel)
+        _to_match_spec(dep.name, dep.version, dep.build, dep.channel)
         for dep in specs.values()
         if isinstance(dep, VersionedDependency) and dep.manager == "conda"
     ]

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -45,10 +45,21 @@ class _BaseDependency(StrictModel):
     selectors: Selectors = Selectors()
 
 
+class PoetrySource(StrictModel):
+    class Config:
+        frozen = True
+
+    name: str
+    url: str
+    default: bool = False
+    secondary: bool = False
+
+
 class VersionedDependency(_BaseDependency):
     version: str
     build: Optional[str] = None
     conda_channel: Optional[str] = None
+    poetry_source: Optional[str] = None
 
 
 class URLDependency(_BaseDependency):
@@ -72,6 +83,7 @@ class LockSpecification(BaseModel):
     sources: List[pathlib.Path]
     virtual_package_repo: Optional[FakeRepoData] = None
     allow_pypi_requests: bool = True
+    poetry_repositories: Optional[List[PoetrySource]] = None
 
     def content_hash(self) -> Dict[str, str]:
         return {
@@ -135,4 +147,8 @@ def aggregate_lock_specs(
         # uniquify metadata, preserving order
         platforms=ordered_union(lock_spec.platforms or [] for lock_spec in lock_specs),
         sources=ordered_union(lock_spec.sources or [] for lock_spec in lock_specs),
+        poetry_repositories=ordered_union(
+            lock_spec.poetry_repositories or [] for lock_spec in lock_specs
+        )
+        or None,
     )

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -45,7 +45,7 @@ class _BaseDependency(StrictModel):
     selectors: Selectors = Selectors()
 
 
-class PoetrySource(StrictModel):
+class PyPIChannel(StrictModel):
     class Config:
         frozen = True
 
@@ -58,8 +58,7 @@ class PoetrySource(StrictModel):
 class VersionedDependency(_BaseDependency):
     version: str
     build: Optional[str] = None
-    conda_channel: Optional[str] = None
-    poetry_source: Optional[str] = None
+    channel: Optional[str] = None
 
 
 class URLDependency(_BaseDependency):
@@ -83,7 +82,7 @@ class LockSpecification(BaseModel):
     sources: List[pathlib.Path]
     virtual_package_repo: Optional[FakeRepoData] = None
     allow_pypi_requests: bool = True
-    poetry_repositories: Optional[List[PoetrySource]] = None
+    pypi_channels: Optional[List[PyPIChannel]] = None
 
     def content_hash(self) -> Dict[str, str]:
         return {
@@ -147,8 +146,8 @@ def aggregate_lock_specs(
         # uniquify metadata, preserving order
         platforms=ordered_union(lock_spec.platforms or [] for lock_spec in lock_specs),
         sources=ordered_union(lock_spec.sources or [] for lock_spec in lock_specs),
-        poetry_repositories=ordered_union(
-            lock_spec.poetry_repositories or [] for lock_spec in lock_specs
+        pypi_channels=ordered_union(
+            lock_spec.pypi_channels or [] for lock_spec in lock_specs
         )
         or None,
     )

--- a/conda_lock/src_parser/conda_common.py
+++ b/conda_lock/src_parser/conda_common.py
@@ -29,5 +29,5 @@ def conda_spec_to_versioned_dep(spec: str, category: str) -> VersionedDependency
         category=category,
         extras=[],
         build=ms.get("build"),
-        conda_channel=channel_str,
+        channel=channel_str,
     )

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -31,7 +31,7 @@ from conda_lock.lookup import get_forward_lookup as get_lookup
 from conda_lock.src_parser import (
     Dependency,
     LockSpecification,
-    PoetrySource,
+    PyPIChannel,
     URLDependency,
     VersionedDependency,
 )
@@ -123,7 +123,7 @@ def parse_poetry_pyproject_toml(
 
     poetry_repositories = []
     for repository in get_in(["tool", "poetry", "source"], contents, {}):
-        source = PoetrySource(**repository)
+        source = PyPIChannel(**repository)
         poetry_repositories.append(source)
 
     for section, default_category in categories.items():
@@ -187,7 +187,7 @@ def parse_poetry_pyproject_toml(
                         optional=optional,
                         category=category,
                         extras=extras,
-                        poetry_source=poetry_source,
+                        channel=poetry_source,
                     )
                 )
 
@@ -200,7 +200,7 @@ def specification_with_dependencies(
     path: pathlib.Path,
     toml_contents: Mapping[str, Any],
     dependencies: List[Dependency],
-    poetry_repositories: Optional[List[PoetrySource]] = None,
+    pypi_channels: Optional[List[PyPIChannel]] = None,
 ) -> LockSpecification:
     force_pypi = set()
     for depname, depattrs in get_in(
@@ -234,7 +234,7 @@ def specification_with_dependencies(
         channels=get_in(["tool", "conda-lock", "channels"], toml_contents, []),
         platforms=get_in(["tool", "conda-lock", "platforms"], toml_contents, []),
         sources=[path],
-        poetry_repositories=poetry_repositories,
+        pypi_channels=pypi_channels,
         allow_pypi_requests=get_in(
             ["tool", "conda-lock", "allow-pypi-requests"], toml_contents, True
         ),


### PR DESCRIPTION
While private sources are currently supported, they do not use the poetry [`source`](https://python-poetry.org/docs/repositories/#installing-from-private-package-sources) concept in pyproject.toml: While specifying `source = pypi` will mark a package to be installed with pip instead of conda, it does not allow specifiying which index the package should come from, nor allow configurig the used indices directly in `pyproject.toml`.

The changes in this PR should make conda-lock aware of poetry sources and also allow providing auth for private sources.

Relies on: https://github.com/conda/conda-lock/pull/323 for providing auth to private indices during installation.

Still WIP - tests still needed.