### PR TITLE
Default PyPI dependencies for pyproject.toml #334

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,8 +388,18 @@ A dependency will also be treated as a `pip` dependency if explicitly marked wit
 [tool.conda-lock.dependencies]
 ampel-ztf = {source = "pypi"}
 ```
+##### Defaulting Poetry Dependency Source to PyPI
 
-In both these cases, the dependencies of `pip`-installable packages will also be
+Alternatively, the above behavior is defaulted for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
+- Defaulting to PyPI dependencies for `[tool.poetry.dependencies]`
+- Defaulting to Conda dependencies for `[tool.conda-lock.dependencies]`
+
+by explicitly providing  `default-poetry-source-pypi = true` in `[tool.conda-lock]` section, e.g.:
+```toml
+[tool.conda-lock]
+default-poetry-source-pypi = true
+```
+In all cases, the dependencies of `pip`-installable packages will also be
 installed with `pip`, unless they were already requested by a `conda`
 dependency.
 

--- a/README.md
+++ b/README.md
@@ -394,10 +394,10 @@ Alternatively, the above behavior is defaulted for all dependencies defined in `
 - Defaulting to PyPI dependencies for `[tool.poetry.dependencies]`
 - Defaulting to Conda dependencies for `[tool.conda-lock.dependencies]`
 
-by explicitly providing  `default-poetry-source-pypi = true` in `[tool.conda-lock]` section, e.g.:
+by explicitly providing  `default-dependencies-to-conda = false` in `[tool.conda-lock.poetry]` section, e.g.:
 ```toml
-[tool.conda-lock]
-default-poetry-source-pypi = true
+[tool.conda-lock.poetry]
+default-dependencies-to-conda = false
 ```
 In all cases, the dependencies of `pip`-installable packages will also be
 installed with `pip`, unless they were already requested by a `conda`

--- a/README.md
+++ b/README.md
@@ -388,17 +388,18 @@ A dependency will also be treated as a `pip` dependency if explicitly marked wit
 [tool.conda-lock.dependencies]
 ampel-ztf = {source = "pypi"}
 ```
-##### Defaulting Poetry Dependency Source to PyPI
+##### Defaulting non-conda dependency sources to PyPI
 
-Alternatively, the above behavior is defaulted for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
-- Defaulting to PyPI dependencies for `[tool.poetry.dependencies]`
-- Defaulting to Conda dependencies for `[tool.conda-lock.dependencies]`
+Alternatively, the above behavior is defaulted for all dependencies defined outside of `[tool.conda-lock.dependencies]`, i.e.:
+- Default to `pip` dependencies for `[tool.poetry.dependencies]`, `[project.dependencies]`, etc.
+- Default to `conda` dependencies for `[tool.conda-lock.dependencies]`
 
-by explicitly providing  `default-dependencies-to-conda = false` in `[tool.conda-lock.poetry]` section, e.g.:
+by explicitly providing  `default-non-conda-source = "pip"` in `[tool.conda-lock]` section, e.g.:
 ```toml
-[tool.conda-lock.poetry]
-default-dependencies-to-conda = false
+[tool.conda-lock]
+default-non-conda-source = "pip"
 ```
+
 In all cases, the dependencies of `pip`-installable packages will also be
 installed with `pip`, unless they were already requested by a `conda`
 dependency.

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -98,6 +98,7 @@ def parse_poetry_pyproject_toml(
     * By default, dependency names are translated to the conda equivalent, with two exceptions:
         - If a dependency has `source = "pypi"`, it is treated as a pip dependency (by name)
         - If a dependency has a url, it is treated as a direct pip dependency (by url)
+        - If all dependencies are defaulted to pypi, `default-poetry-source-pypi = true`
 
     * markers are not supported
 
@@ -134,11 +135,18 @@ def parse_poetry_pyproject_toml(
                 url = depattrs.get("url", None)
                 optional = depattrs.get("optional", False)
                 extras = depattrs.get("extras", [])
+                default_poetry_source_pypi = get_in(
+                    ["tool", "conda-lock", "default-poetry-source-pypi"],
+                    contents,
+                    False,
+                )
                 # If a dependency is explicitly marked as sourced from pypi,
-                # or is a URL dependency, delegate to the pip section
+                # or is a URL dependency,
+                # or if default to pypi is marked explicitly, delegate to the pip section,
                 if (
                     depattrs.get("source", None) == "pypi"
                     or poetry_version_spec is None
+                    or default_poetry_source_pypi
                 ):
                     manager = "pip"
                 # TODO: support additional features such as markers for things like sys_platform, platform_system

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -45,12 +45,12 @@ python = "3.9"
 ampel-ztf = {version = "^0.8.0-alpha.2", source = "pypi"}
 ```
 
-Alternatively, explicitly providing  `default-dependencies-to-conda = false` in the `[tool.conda-lock.poetry]` section will set PyPI as the default source for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
-- Default to PyPI dependencies for `[tool.poetry.dependencies]`
-- Default to Conda dependencies for `[tool.conda-lock.dependencies]`
+Alternatively, explicitly providing  `default-non-conda-source = "pip"` in the `[tool.conda-lock]` section will treat all non-conda dependencies -- all dependencies defined outside of `[tool.conda-lock.dependencies]` -- as `pip` dependencies, i.e.:
+- Default to `pip` dependencies for `[tool.poetry.dependencies]`, `[project.dependencies]`, etc.
+- Default to `conda` dependencies for `[tool.conda-lock.dependencies]`
 ```toml
-[tool.conda-lock.poetry]
-default-dependencies-to-conda = false
+[tool.conda-lock]
+default-non-conda-source = "pip"
 ```
 
 In all cases, the dependencies of `pip`-installable packages will also be

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -45,12 +45,12 @@ python = "3.9"
 ampel-ztf = {version = "^0.8.0-alpha.2", source = "pypi"}
 ```
 
-Alternatively, explicitly providing  `default-poetry-source-pypi = true` in the `[tool.conda-lock]` section will set PyPI as the default source for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
+Alternatively, explicitly providing  `default-dependencies-to-conda = false` in the `[tool.conda-lock.poetry]` section will set PyPI as the default source for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
 - Default to PyPI dependencies for `[tool.poetry.dependencies]`
 - Default to Conda dependencies for `[tool.conda-lock.dependencies]`
 ```toml
-[tool.conda-lock]
-default-poetry-source-pypi = true
+[tool.conda-lock.poetry]
+default-dependencies-to-conda = false
 ```
 
 In all cases, the dependencies of `pip`-installable packages will also be

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -45,6 +45,14 @@ python = "3.9"
 ampel-ztf = {version = "^0.8.0-alpha.2", source = "pypi"}
 ```
 
-In both these cases, the dependencies of `pip`-installable packages will also be
+Alternatively, explicitly providing  `default-poetry-source-pypi = true` in the `[tool.conda-lock]` section will set PyPI as the default source for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
+- Default to PyPI dependencies for `[tool.poetry.dependencies]`
+- Default to Conda dependencies for `[tool.conda-lock.dependencies]`
+```toml
+[tool.conda-lock]
+default-poetry-source-pypi = true
+```
+
+In all cases, the dependencies of `pip`-installable packages will also be
 installed with `pip`, unless they were already requested by a `conda`
 dependency.

--- a/docs/src_pyproject.md
+++ b/docs/src_pyproject.md
@@ -77,12 +77,12 @@ python = "3.9"
 ampel-ztf = {version = "^0.8.0-alpha.2", source = "pypi"}
 ```
 
-Alternatively, explicitly providing  `default-dependencies-to-conda = false` in the `[tool.conda-lock.poetry]` section will set PyPI as the default source for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
-- Default to PyPI dependencies for `[tool.poetry.dependencies]`
-- Default to Conda dependencies for `[tool.conda-lock.dependencies]`
+Alternatively, explicitly providing  `default-non-conda-source = "pip"` in the `[tool.conda-lock]` section will treat all non-conda dependencies -- all dependencies defined outside of `[tool.conda-lock.dependencies]` -- as `pip` dependencies, i.e.:
+- Default to `pip` dependencies for `[tool.poetry.dependencies]`, `[project.dependencies]`, etc.
+- Default to `conda` dependencies for `[tool.conda-lock.dependencies]`
 ```toml
-[tool.conda-lock.poetry]
-default-dependencies-to-conda = false
+[tool.conda-lock]
+default-non-conda-source = "pip"
 ```
 
 In all cases, the dependencies of `pip`-installable packages will also be

--- a/docs/src_pyproject.md
+++ b/docs/src_pyproject.md
@@ -77,7 +77,15 @@ python = "3.9"
 ampel-ztf = {version = "^0.8.0-alpha.2", source = "pypi"}
 ```
 
-In both these cases, the dependencies of `pip`-installable packages will also be
+Alternatively, explicitly providing  `default-poetry-source-pypi = true` in the `[tool.conda-lock]` section will set PyPI as the default source for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
+- Default to PyPI dependencies for `[tool.poetry.dependencies]`
+- Default to Conda dependencies for `[tool.conda-lock.dependencies]`
+```toml
+[tool.conda-lock]
+default-poetry-source-pypi = true
+```
+
+In all cases, the dependencies of `pip`-installable packages will also be
 installed with `pip`, unless they were already requested by a `conda`
 dependency.
 

--- a/docs/src_pyproject.md
+++ b/docs/src_pyproject.md
@@ -77,12 +77,12 @@ python = "3.9"
 ampel-ztf = {version = "^0.8.0-alpha.2", source = "pypi"}
 ```
 
-Alternatively, explicitly providing  `default-poetry-source-pypi = true` in the `[tool.conda-lock]` section will set PyPI as the default source for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
+Alternatively, explicitly providing  `default-dependencies-to-conda = false` in the `[tool.conda-lock.poetry]` section will set PyPI as the default source for all dependencies defined in `[tool.poetry.dependencies]`, i.e.:
 - Default to PyPI dependencies for `[tool.poetry.dependencies]`
 - Default to Conda dependencies for `[tool.conda-lock.dependencies]`
 ```toml
-[tool.conda-lock]
-default-poetry-source-pypi = true
+[tool.conda-lock.poetry]
+default-dependencies-to-conda = false
 ```
 
 In all cases, the dependencies of `pip`-installable packages will also be

--- a/tests/test-flit-default-pip/pyproject.toml
+++ b/tests/test-flit-default-pip/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.flit.metadata]
+name = "conda-lock-test-poetry"
+version = "0.0.1"
+description = ""
+authors = ["conda-lock"]
+requires = [
+    "requests >=2.13.0",
+    "toml >=0.10",
+    "tomlkit >=0.7",
+    ]
+
+[tool.flit.metadata.requires-extra]
+test = [
+    "pytest >=5.1.0"
+]
+
+[build-system]
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
+
+[tool.conda-lock]
+channels = [
+    'defaults'
+]
+default-non-conda-source = "pip"
+
+[tool.conda-lock.dependencies]
+sqlite = "<3.34"
+certifi = ">=2019.11.28"

--- a/tests/test-pdm-default-pip/pyproject.toml
+++ b/tests/test-pdm-default-pip/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "conda-lock-test-pdm"
+authors = ["conda-lock"]
+description = ""
+requires-python = ">=3.7"
+dependencies = [
+  "requests >=2.13.0",
+  "toml >=0.10",
+  "tomlkit >=0.7",
+]
+
+[project.optional-dependencies]
+cli = ["click >=7.0"]
+
+[tool.pdm.dev-dependencies]
+test = [
+  "pytest >=5.1.0",
+]
+
+[tool.conda-lock]
+channels = [
+  "defaults",
+]
+default-non-conda-source = "pip"
+
+[tool.conda-lock.dependencies]
+certifi = ">=2019.11.28"
+sqlite = "<3.34"

--- a/tests/test-poetry-default-pip/pyproject.toml
+++ b/tests/test-poetry-default-pip/pyproject.toml
@@ -23,9 +23,7 @@ build-backend = "poetry.masonry.api"
 channels = [
     'defaults'
 ]
-
-[tool.conda-lock.poetry]
-default-dependencies-to-conda = false
+default-non-conda-source = "pip"
 
 [tool.conda-lock.dependencies]
 sqlite = "<3.34"

--- a/tests/test-poetry-default-pypi/pyproject.toml
+++ b/tests/test-poetry-default-pypi/pyproject.toml
@@ -20,10 +20,12 @@ requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
 [tool.conda-lock]
-default-poetry-source-pypi = true
 channels = [
     'defaults'
 ]
+
+[tool.conda-lock.poetry]
+default-dependencies-to-conda = false
 
 [tool.conda-lock.dependencies]
 sqlite = "<3.34"

--- a/tests/test-poetry-default-pypi/pyproject.toml
+++ b/tests/test-poetry-default-pypi/pyproject.toml
@@ -1,0 +1,30 @@
+[tool.poetry]
+name = "conda-lock-test-poetry"
+version = "0.0.1"
+description = ""
+authors = ["conda-lock"]
+
+[tool.poetry.dependencies]
+requests = "^2.13.0"
+toml = ">=0.10"
+tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }
+
+[tool.poetry.dev-dependencies]
+pytest = "~5.1.0"
+
+[tool.poetry.extras]
+tomlkit = ["tomlkit"]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.conda-lock]
+default-poetry-source-pypi = true
+channels = [
+    'defaults'
+]
+
+[tool.conda-lock.dependencies]
+sqlite = "<3.34"
+certifi = ">=2019.11.28"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -183,8 +183,8 @@ def poetry_pyproject_toml(tmp_path: Path):
 
 
 @pytest.fixture
-def poetry_pyproject_toml_default_pypi(tmp_path: Path):
-    return clone_test_dir("test-poetry-default-pypi", tmp_path).joinpath(
+def poetry_pyproject_toml_default_pip(tmp_path: Path):
+    return clone_test_dir("test-poetry-default-pip", tmp_path).joinpath(
         "pyproject.toml"
     )
 
@@ -211,6 +211,16 @@ def flit_pyproject_toml(tmp_path: Path):
 @pytest.fixture
 def pdm_pyproject_toml(tmp_path: Path):
     return clone_test_dir("test-pdm", tmp_path).joinpath("pyproject.toml")
+
+
+@pytest.fixture
+def flit_pyproject_toml_default_pip(tmp_path: Path):
+    return clone_test_dir("test-flit-default-pip", tmp_path).joinpath("pyproject.toml")
+
+
+@pytest.fixture
+def pdm_pyproject_toml_default_pip(tmp_path: Path):
+    return clone_test_dir("test-pdm-default-pip", tmp_path).joinpath("pyproject.toml")
 
 
 @pytest.fixture
@@ -609,9 +619,9 @@ def test_parse_poetry(poetry_pyproject_toml: Path):
     assert res.channels == [Channel.from_string("defaults")]
 
 
-def test_parse_poetry_default_pypi(poetry_pyproject_toml_default_pypi: Path):
+def test_parse_poetry_default_pip(poetry_pyproject_toml_default_pip: Path):
     res = parse_pyproject_toml(
-        poetry_pyproject_toml_default_pypi,
+        poetry_pyproject_toml_default_pip,
     )
 
     specs = {
@@ -724,6 +734,23 @@ def test_parse_flit(flit_pyproject_toml: Path):
     assert res.channels == [Channel.from_string("defaults")]
 
 
+def test_parse_flit_default_pip(flit_pyproject_toml_default_pip: Path):
+    res = parse_pyproject_toml(
+        flit_pyproject_toml_default_pip,
+    )
+
+    specs = {
+        dep.name: typing.cast(VersionedDependency, dep) for dep in res.dependencies
+    }
+
+    assert specs["sqlite"].manager == "conda"
+    assert specs["certifi"].manager == "conda"
+    assert specs["requests"].manager == "pip"
+    assert specs["toml"].manager == "pip"
+    assert specs["pytest"].manager == "pip"
+    assert specs["tomlkit"].manager == "pip"
+
+
 def test_parse_pdm(pdm_pyproject_toml: Path):
     res = parse_pyproject_toml(
         pdm_pyproject_toml,
@@ -749,6 +776,24 @@ def test_parse_pdm(pdm_pyproject_toml: Path):
     assert specs["pytest"].category == "dev"
     # Conda channels
     assert res.channels == [Channel.from_string("defaults")]
+
+
+def test_parse_pdm_default_pip(pdm_pyproject_toml_default_pip: Path):
+    res = parse_pyproject_toml(
+        pdm_pyproject_toml_default_pip,
+    )
+
+    specs = {
+        dep.name: typing.cast(VersionedDependency, dep) for dep in res.dependencies
+    }
+
+    assert specs["sqlite"].manager == "conda"
+    assert specs["certifi"].manager == "conda"
+    assert specs["requests"].manager == "pip"
+    assert specs["toml"].manager == "pip"
+    assert specs["pytest"].manager == "pip"
+    assert specs["tomlkit"].manager == "pip"
+    assert specs["click"].manager == "pip"
 
 
 def test_run_lock(

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -183,6 +183,13 @@ def poetry_pyproject_toml(tmp_path: Path):
 
 
 @pytest.fixture
+def poetry_pyproject_toml_default_pypi(tmp_path: Path):
+    return clone_test_dir("test-poetry-default-pypi", tmp_path).joinpath(
+        "pyproject.toml"
+    )
+
+
+@pytest.fixture
 def poetry_pyproject_toml_no_pypi(tmp_path: Path):
     return clone_test_dir("test-poetry-no-pypi", tmp_path).joinpath("pyproject.toml")
 
@@ -591,6 +598,23 @@ def test_parse_poetry(poetry_pyproject_toml: Path):
     assert specs["tomlkit"].category == "tomlkit"
 
     assert res.channels == [Channel.from_string("defaults")]
+
+
+def test_parse_poetry_default_pypi(poetry_pyproject_toml_default_pypi: Path):
+    res = parse_pyproject_toml(
+        poetry_pyproject_toml_default_pypi,
+    )
+
+    specs = {
+        dep.name: typing.cast(VersionedDependency, dep) for dep in res.dependencies
+    }
+
+    assert specs["sqlite"].manager == "conda"
+    assert specs["certifi"].manager == "conda"
+    assert specs["requests"].manager == "pip"
+    assert specs["toml"].manager == "pip"
+    assert specs["pytest"].manager == "pip"
+    assert specs["tomlkit"].manager == "pip"
 
 
 def test_parse_poetry_no_pypi(poetry_pyproject_toml_no_pypi: Path):

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -636,12 +636,11 @@ def test_parse_poetry(poetry_pyproject_toml: Path):
 
 
 def test_parse_poetry_default_pip(poetry_pyproject_toml_default_pip: Path):
-    res = parse_pyproject_toml(
-        poetry_pyproject_toml_default_pip,
-    )
+    res = parse_pyproject_toml(poetry_pyproject_toml_default_pip, ["linux-64"])
 
     specs = {
-        dep.name: typing.cast(VersionedDependency, dep) for dep in res.dependencies
+        dep.name: typing.cast(VersionedDependency, dep)
+        for dep in res.dependencies["linux-64"]
     }
 
     assert specs["sqlite"].manager == "conda"
@@ -752,12 +751,11 @@ def test_parse_flit(flit_pyproject_toml: Path):
 
 
 def test_parse_flit_default_pip(flit_pyproject_toml_default_pip: Path):
-    res = parse_pyproject_toml(
-        flit_pyproject_toml_default_pip,
-    )
+    res = parse_pyproject_toml(flit_pyproject_toml_default_pip, ["linux-64"])
 
     specs = {
-        dep.name: typing.cast(VersionedDependency, dep) for dep in res.dependencies
+        dep.name: typing.cast(VersionedDependency, dep)
+        for dep in res.dependencies["linux-64"]
     }
 
     assert specs["sqlite"].manager == "conda"
@@ -795,12 +793,11 @@ def test_parse_pdm(pdm_pyproject_toml: Path):
 
 
 def test_parse_pdm_default_pip(pdm_pyproject_toml_default_pip: Path):
-    res = parse_pyproject_toml(
-        pdm_pyproject_toml_default_pip,
-    )
+    res = parse_pyproject_toml(pdm_pyproject_toml_default_pip, ["linux-64"])
 
     specs = {
-        dep.name: typing.cast(VersionedDependency, dep) for dep in res.dependencies
+        dep.name: typing.cast(VersionedDependency, dep)
+        for dep in res.dependencies["linux-64"]
     }
 
     assert specs["sqlite"].manager == "conda"


### PR DESCRIPTION
Quick draft implementation of changes discussed in #334:

Implements a `default-poetry-source-pypi` flag in `[tool.conda-lock]` to default to `source = "pypi"` for all dependencies in `[tool.poetry.dependencies]`, i.e.:
- Defaulting to PyPI dependencies for `[tool.poetry.dependencies]`
- Defaulting to Conda dependencies for `[tool.conda-lock.dependencies]`

by explicitly providing  `default-poetry-source-pypi = true` in `[tool.conda-lock]` section, e.g.:
```toml
[tool.conda-lock]
default-poetry-source-pypi = true
```

Updated Readme and tests to reflect changes. Please let me know any thoughts or comments!