### PR TITLE
Move test_channel.py to tests/

### DIFF
--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,6 +1,6 @@
 import typing
 
-from .channel import _detect_used_env_var, _env_var_normalize
+from conda_lock.models.channel import _detect_used_env_var, _env_var_normalize
 
 
 if typing.TYPE_CHECKING:


### PR DESCRIPTION
I'm not sure why there was this tests file in the source directory. I think it belongs in `tests/`.

Maybe it had to do with the circular import we fixed in #347?