### PR TITLE
Prevent PyYAML from sorting keys

### DIFF
--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -166,5 +166,6 @@ def write_conda_lock_file(
                     content.json(by_alias=True, exclude_unset=True, exclude_none=True)
                 ),
             },
-            f,
+            stream=f,
+            sort_keys=False,
         )


### PR DESCRIPTION
When keys are sorted, the lockfile packages are represented in an awkward order with the package "name" near the bottom.