### PR TITLE
Parse Platforms Before Determining Dependencies

### DIFF
--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -7,7 +7,10 @@ from conda_lock.common import ordered_union
 from conda_lock.models.channel import Channel
 from conda_lock.models.lock_spec import Dependency, LockSpecification
 from conda_lock.src_parser.aggregation import aggregate_lock_specs
-from conda_lock.src_parser.environment_yaml import parse_environment_file
+from conda_lock.src_parser.environment_yaml import (
+    parse_environment_file,
+    parse_platforms_from_env_file,
+)
 from conda_lock.src_parser.meta_yaml import parse_meta_yaml_file
 from conda_lock.src_parser.pyproject_toml import parse_pyproject_toml
 from conda_lock.virtual_package import FakeRepoData
@@ -35,9 +38,7 @@ def _parse_platforms_from_srcs(src_files: List[pathlib.Path]) -> List[str]:
         elif src_file.name == "pyproject.toml":
             all_file_platforms.append(parse_pyproject_toml(src_file).platforms)
         else:
-            all_file_platforms.append(
-                parse_environment_file(src_file, DEFAULT_PLATFORMS).platforms
-            )
+            all_file_platforms.append(parse_platforms_from_env_file(src_file))
 
     return ordered_union(all_file_platforms)
 

--- a/conda_lock/src_parser/environment_yaml.py
+++ b/conda_lock/src_parser/environment_yaml.py
@@ -96,6 +96,20 @@ def _parse_environment_file_for_platform(
     )
 
 
+def parse_platforms_from_env_file(environment_file: pathlib.Path) -> List[str]:
+    """
+    Parse the list of platforms from an environment-yaml file
+    """
+    if not environment_file.exists():
+        raise FileNotFoundError(f"{environment_file} not found")
+
+    with environment_file.open("r") as fo:
+        content = fo.read()
+        env_yaml_data = yaml.safe_load(content)
+
+    return env_yaml_data.get("platforms", [])
+
+
 def parse_environment_file(
     environment_file: pathlib.Path,
     given_platforms: Optional[Sequence[str]],

--- a/conda_lock/src_parser/environment_yaml.py
+++ b/conda_lock/src_parser/environment_yaml.py
@@ -2,7 +2,7 @@ import pathlib
 import re
 import sys
 
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Tuple
 
 import yaml
 
@@ -112,9 +112,7 @@ def parse_platforms_from_env_file(environment_file: pathlib.Path) -> List[str]:
 
 def parse_environment_file(
     environment_file: pathlib.Path,
-    given_platforms: Optional[Sequence[str]],
-    *,
-    default_platforms: List[str] = [],
+    platforms: List[str],
 ) -> LockSpecification:
     """Parse a simple environment-yaml file for dependencies assuming the target platforms.
 
@@ -128,15 +126,6 @@ def parse_environment_file(
 
     with environment_file.open("r") as fo:
         content = fo.read()
-        env_yaml_data = yaml.safe_load(content)
-
-    # Get list of platforms from the input file
-    yaml_platforms: Optional[List[str]] = env_yaml_data.get("platforms")
-    # Final list of platforms is the following order of priority
-    # 1) List Passed in via the -p flag (if any given)
-    # 2) List From the YAML File (if specified)
-    # 3) Default List of Platforms to Render
-    platforms = list(given_platforms or yaml_platforms or default_platforms)
 
     # Parse with selectors for each target platform
     spec = aggregate_lock_specs(

--- a/tests/test-multi-sources/dev.yml
+++ b/tests/test-multi-sources/dev.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - pytest

--- a/tests/test-multi-sources/main.yml
+++ b/tests/test-multi-sources/main.yml
@@ -1,0 +1,6 @@
+dependencies:
+  - python <3.11
+platforms:
+  - osx-arm64
+  - osx-64
+  - linux-64

--- a/tests/test-multi-sources/pyproject.toml
+++ b/tests/test-multi-sources/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "conda-lock-test-poetry"
+version = "0.0.1"
+description = ""
+authors = ["conda-lock"]
+
+[tool.poetry.dependencies]
+pandas = "^1.5.0"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.conda-lock]
+platforms = [
+    "win-64",
+    "osx-arm64"
+]

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -70,7 +70,10 @@ from conda_lock.src_parser import (
     parse_meta_yaml_file,
 )
 from conda_lock.src_parser.aggregation import aggregate_lock_specs
-from conda_lock.src_parser.environment_yaml import parse_environment_file
+from conda_lock.src_parser.environment_yaml import (
+    parse_environment_file,
+    parse_platforms_from_env_file,
+)
 from conda_lock.src_parser.pyproject_toml import (
     parse_pyproject_toml,
     poetry_version_to_conda_version,
@@ -360,7 +363,8 @@ def test_parse_environment_file_with_pip(pip_environment: Path):
 
 
 def test_parse_env_file_with_filters_no_args(filter_conda_environment: Path):
-    res = parse_environment_file(filter_conda_environment, None)
+    platforms = parse_platforms_from_env_file(filter_conda_environment)
+    res = parse_environment_file(filter_conda_environment, platforms)
     assert all(x in res.platforms for x in ["osx-arm64", "osx-64", "linux-64"])
     assert res.channels == [Channel.from_string("conda-forge")]
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -67,6 +67,7 @@ from conda_lock.pypi_solver import parse_pip_requirement, solve_pypi
 from conda_lock.src_parser import (
     DEFAULT_PLATFORMS,
     LockSpecification,
+    _parse_platforms_from_srcs,
     parse_meta_yaml_file,
 )
 from conda_lock.src_parser.aggregation import aggregate_lock_specs
@@ -213,6 +214,12 @@ def env_with_uppercase_pip(tmp_path: Path):
 @pytest.fixture
 def git_metadata_zlib_environment(tmp_path: Path):
     return clone_test_dir("zlib", tmp_path).joinpath("environment.yml")
+
+
+@pytest.fixture
+def multi_source_env(tmp_path: Path):
+    f = clone_test_dir("test-multi-sources", tmp_path)
+    return [f.joinpath("main.yml"), f.joinpath("pyproject.toml"), f.joinpath("dev.yml")]
 
 
 @pytest.fixture(
@@ -425,6 +432,11 @@ def test_parse_env_file_with_filters_defaults(filter_conda_environment: Path):
             ),
         ]
     )
+
+
+def test_parse_platforms_from_multi_sources(multi_source_env):
+    platforms = _parse_platforms_from_srcs(multi_source_env)
+    assert platforms == ["osx-arm64", "osx-64", "linux-64", "win-64"]
 
 
 def test_choose_wheel() -> None:


### PR DESCRIPTION
### Description
Closes #337. This PR changes `_parse_source_files` to first determine the list of platforms to render for by reading the source files. It will only do so if an explicit list of platforms have not been passed in.