### PR TITLE
Fix 'allow_pypi_requests' with multiple pyproject

### DIFF
--- a/conda_lock/src_parser/aggregation.py
+++ b/conda_lock/src_parser/aggregation.py
@@ -40,4 +40,7 @@ def aggregate_lock_specs(
         # uniquify metadata, preserving order
         platforms=ordered_union(lock_spec.platforms or [] for lock_spec in lock_specs),
         sources=ordered_union(lock_spec.sources or [] for lock_spec in lock_specs),
+        allow_pypi_requests=all(
+            lock_spec.allow_pypi_requests for lock_spec in lock_specs
+        ),
     )

--- a/tests/test-poetry-no-pypi/other_project1/pyproject.toml
+++ b/tests/test-poetry-no-pypi/other_project1/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.poetry]
+name = "conda-lock-test-poetry"
+version = "0.0.1"
+description = ""
+authors = ["conda-lock"]
+
+[tool.poetry.dependencies]
+requests = "^2.13.0"
+toml = ">=0.10"
+tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }
+
+[tool.poetry.dev-dependencies]
+pytest = "~5.1.0"
+
+[tool.poetry.extras]
+tomlkit = ["tomlkit"]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.conda-lock]
+channels = [
+    'defaults'
+]
+
+[tool.conda-lock.dependencies]
+sqlite = "<3.34"
+certifi = ">=2019.11.28"

--- a/tests/test-poetry-no-pypi/other_project2/pyproject.toml
+++ b/tests/test-poetry-no-pypi/other_project2/pyproject.toml
@@ -1,0 +1,30 @@
+[tool.poetry]
+name = "conda-lock-test-poetry"
+version = "0.0.1"
+description = ""
+authors = ["conda-lock"]
+
+[tool.poetry.dependencies]
+requests = "^2.13.0"
+toml = ">=0.10"
+tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }
+
+[tool.poetry.dev-dependencies]
+pytest = "~5.1.0"
+
+[tool.poetry.extras]
+tomlkit = ["tomlkit"]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.conda-lock]
+allow-pypi-requests = true
+channels = [
+    'defaults'
+]
+
+[tool.conda-lock.dependencies]
+sqlite = "<3.34"
+certifi = ">=2019.11.28"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -14,7 +14,7 @@ import uuid
 
 from glob import glob
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 from unittest.mock import MagicMock
 from urllib.parse import urldefrag, urlsplit
 
@@ -185,6 +185,15 @@ def poetry_pyproject_toml(tmp_path: Path):
 @pytest.fixture
 def poetry_pyproject_toml_no_pypi(tmp_path: Path):
     return clone_test_dir("test-poetry-no-pypi", tmp_path).joinpath("pyproject.toml")
+
+
+@pytest.fixture
+def poetry_pyproject_toml_no_pypi_other_projects(tmp_path: Path):
+    tmp = clone_test_dir("test-poetry-no-pypi", tmp_path)
+    return [
+        tmp.joinpath("other_project1/pyproject.toml"),
+        tmp.joinpath("other_project2/pyproject.toml"),
+    ]
 
 
 @pytest.fixture
@@ -598,6 +607,31 @@ def test_parse_poetry_no_pypi(poetry_pyproject_toml_no_pypi: Path):
         poetry_pyproject_toml_no_pypi,
     )
     assert res.allow_pypi_requests is False
+
+
+def test_poetry_no_pypi_multiple_pyprojects(
+    poetry_pyproject_toml_no_pypi: Path,
+    poetry_pyproject_toml_no_pypi_other_projects: List[Path],
+):
+    virtual_package_repo = default_virtual_package_repodata()
+    with virtual_package_repo:
+        spec = make_lock_spec(
+            src_files=poetry_pyproject_toml_no_pypi_other_projects,
+            virtual_package_repo=virtual_package_repo,
+        )
+        assert (
+            spec.allow_pypi_requests is True
+        ), "PyPI requests should be allowed when all pyprojects.toml allow PyPI requests"
+        spec = make_lock_spec(
+            src_files=[
+                *poetry_pyproject_toml_no_pypi_other_projects,
+                poetry_pyproject_toml_no_pypi,
+            ],
+            virtual_package_repo=virtual_package_repo,
+        )
+        assert (
+            spec.allow_pypi_requests is False
+        ), "PyPI requests should be forbidden when at least one pyproject.toml forbids PyPI requests"
 
 
 def test_prepare_repositories_pool():


### PR DESCRIPTION
### Description

There was an issue remaining after [my previous MR](https://github.com/conda/conda-lock/pull/304) when using conda-lock with multiple `pyproject.toml`: the option to prevent pypi requests was ignored. Here is a proposed fix for this.
