### PR TITLE
feat: add support for git to lockfile

### DIFF
--- a/conda_lock/models/lock_spec.py
+++ b/conda_lock/models/lock_spec.py
@@ -31,8 +31,11 @@ class URLDependency(_BaseDependency):
     url: str
     hashes: List[str]
 
+class VCSDependency(_BaseDependency):
+    source: str
+    vcs: str
 
-Dependency = Union[VersionedDependency, URLDependency]
+Dependency = Union[VersionedDependency, URLDependency, VCSDependency]
 
 
 class Package(StrictModel):

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -33,6 +33,7 @@ from conda_lock.models.lock_spec import (
     Dependency,
     LockSpecification,
     URLDependency,
+    VCSDependency,
     VersionedDependency,
 )
 
@@ -339,7 +340,14 @@ def parse_python_requirement(
         conda_dep_name = name
     extras = list(parsed_req.extras)
 
-    if parsed_req.url:  # type: ignore[attr-defined]
+    if parsed_req.url and parsed_req.url.startswith('git+'):
+        return VCSDependency(
+            name=conda_dep_name,
+            source=parsed_req.url[4:],
+            manager=manager,
+            vcs='git',
+        )
+    elif parsed_req.url:  # type: ignore[attr-defined]
         assert conda_version in {"", "*", None}
         url, frag = urldefrag(parsed_req.url)  # type: ignore[attr-defined]
         return URLDependency(


### PR DESCRIPTION
Closes https://github.com/conda/conda-lock/issues/392

This is an incredibly hacky solution for https://github.com/conda/conda-lock/issues/392, could use some additional direciton on making this more robust (does anyone know a package parser/upstream efforts to get package parsers that resolve git forges?)