### PR TITLE
Update the `seperator_munge_get` to provide flexibility for dependency lookup

### DIFF
--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -41,7 +41,19 @@ def _apply_categories(
             try:
                 return d[key.replace("-", "_")]
             except KeyError:
-                return d[key.replace("_", "-")]
+                try:
+                    return d[key.replace("_", "-")]
+                except KeyError:
+                    # for bullet-python or python-tzdata
+                    try:
+                        attempted_split = key.split("_")[0].split("-")[0]
+                        if attempted_split == 'python':
+                            attempted_split = key.split("_")[-1].split('-')[-1]
+                        return d[attempted_split]
+                    except KeyError:
+                        list(d.keys())
+                        raise KeyError(f"Could not find {key} in list of dependencies: {list(d.keys())}")
+
 
     for name, request in requested.items():
         todo: List[str] = list()


### PR DESCRIPTION
The fix in this PR adresses two example environment yamls,

In this example `bullet-python` a dependency of `pytest-wdl` breaks `seperator_munge_get`
```
name: python
platforms:
  - linux-64
  - osx-64
channels:
  - bioconda
  - conda-forge
dependencies:
  - python=3.9.12
  - pip
  - miniwdl=1.2.3
  - pip:
    - pytest-wdl
```

In this example `python-tzdata` breaks `seperator_munge_get`,

```
name: python
platforms:
  - linux-64
  - osx-64
channels:
  - bioconda
  - conda-forge
dependencies:
  - python=3.9.12
  - pybedtools
  - pip
  - pip:
    - pandas==1.3.5
```
