### PR TITLE
Fix import in _vendor

### DIFF
--- a/conda_lock/_vendor/conda/models/version.py
+++ b/conda_lock/_vendor/conda/models/version.py
@@ -10,7 +10,7 @@ from itertools import zip_longest
 try:
     from tlz.functoolz import excepts
 except ImportError:
-    from conda_lock._vendor.conda._vendor.toolz.functoolz import excepts
+    from conda_lock._vendor.conda._vendor.toolz import excepts
 
 from ..exceptions import InvalidVersionSpec
 


### PR DESCRIPTION
### Description

Found an incorrect import that breaks `conda-lock` when `toolz` is not installed.