### PR TITLE
Create a preliminary internal v2 lockfile schema but enforce v1

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -54,7 +54,7 @@ from conda_lock.invoke_conda import (
     is_micromamba,
 )
 from conda_lock.lockfile import parse_conda_lock_file, write_conda_lock_file
-from conda_lock.lockfile.models import (
+from conda_lock.lockfile.v1.models import (
     GitMeta,
     InputMeta,
     LockedDependency,

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -54,7 +54,7 @@ from conda_lock.invoke_conda import (
     is_micromamba,
 )
 from conda_lock.lockfile import parse_conda_lock_file, write_conda_lock_file
-from conda_lock.lockfile.v1.models import (
+from conda_lock.lockfile.v2prelim.models import (
     GitMeta,
     InputMeta,
     LockedDependency,

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -53,7 +53,8 @@ from conda_lock.invoke_conda import (
     determine_conda_executable,
     is_micromamba,
 )
-from conda_lock.lockfile import (
+from conda_lock.lockfile import parse_conda_lock_file, write_conda_lock_file
+from conda_lock.lockfile.models import (
     GitMeta,
     InputMeta,
     LockedDependency,
@@ -62,8 +63,6 @@ from conda_lock.lockfile import (
     MetadataOption,
     TimeMeta,
     UpdateSpecification,
-    parse_conda_lock_file,
-    write_conda_lock_file,
 )
 from conda_lock.lookup import set_lookup_location
 from conda_lock.models.channel import Channel

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -25,7 +25,7 @@ from conda_lock.invoke_conda import (
     is_micromamba,
 )
 from conda_lock.lockfile import apply_categories
-from conda_lock.lockfile.v1.models import HashModel, LockedDependency
+from conda_lock.lockfile.v2prelim.models import HashModel, LockedDependency
 from conda_lock.models.channel import Channel
 from conda_lock.models.lock_spec import Dependency, VersionedDependency
 

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -24,7 +24,8 @@ from conda_lock.invoke_conda import (
     conda_pkgs_dir,
     is_micromamba,
 )
-from conda_lock.lockfile import HashModel, LockedDependency, apply_categories
+from conda_lock.lockfile import apply_categories
+from conda_lock.lockfile.models import HashModel, LockedDependency
 from conda_lock.models.channel import Channel
 from conda_lock.models.lock_spec import Dependency, VersionedDependency
 

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -25,7 +25,7 @@ from conda_lock.invoke_conda import (
     is_micromamba,
 )
 from conda_lock.lockfile import apply_categories
-from conda_lock.lockfile.models import HashModel, LockedDependency
+from conda_lock.lockfile.v1.models import HashModel, LockedDependency
 from conda_lock.models.channel import Channel
 from conda_lock.models.lock_spec import Dependency, VersionedDependency
 

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -7,7 +7,11 @@ from typing import Any, Collection, Dict, List, Mapping, Optional, Sequence, Set
 
 import yaml
 
-from conda_lock.lockfile.v1.models import LockedDependency, Lockfile, MetadataOption
+from conda_lock.lockfile.v2prelim.models import (
+    LockedDependency,
+    Lockfile,
+    MetadataOption,
+)
 from conda_lock.lookup import conda_name_to_pypi_name
 from conda_lock.models.lock_spec import Dependency
 

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -7,19 +7,9 @@ from typing import Any, Collection, Dict, List, Mapping, Optional, Sequence, Set
 
 import yaml
 
+from conda_lock.lockfile.models import LockedDependency, Lockfile, MetadataOption
 from conda_lock.lookup import conda_name_to_pypi_name
 from conda_lock.models.lock_spec import Dependency
-
-from .models import DependencySource as DependencySource
-from .models import GitMeta as GitMeta
-from .models import HashModel as HashModel
-from .models import InputMeta as InputMeta
-from .models import LockedDependency, Lockfile
-from .models import LockKey as LockKey
-from .models import LockMeta as LockMeta
-from .models import MetadataOption
-from .models import TimeMeta as TimeMeta
-from .models import UpdateSpecification as UpdateSpecification
 
 
 def _seperator_munge_get(

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Collection, Dict, List, Mapping, Optional, Sequence, Set
 
 import yaml
 
-from conda_lock.lockfile.models import LockedDependency, Lockfile, MetadataOption
+from conda_lock.lockfile.v1.models import LockedDependency, Lockfile, MetadataOption
 from conda_lock.lookup import conda_name_to_pypi_name
 from conda_lock.models.lock_spec import Dependency
 

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -1,9 +1,8 @@
-import json
 import pathlib
 
 from collections import defaultdict
 from textwrap import dedent
-from typing import Any, Collection, Dict, List, Mapping, Optional, Sequence, Set, Union
+from typing import Collection, Dict, List, Mapping, Optional, Sequence, Set, Union
 
 import yaml
 
@@ -199,23 +198,5 @@ def write_conda_lock_file(
                     conda-lock {metadata_flags}{' '.join('-f '+path for path in content.metadata.sources)} --lockfile {path.name}
                 """
             )
-
-        output: Dict[str, Any] = {
-            "version": Lockfile.version,
-            "metadata": json.loads(
-                content.metadata.json(
-                    by_alias=True, exclude_unset=True, exclude_none=True
-                )
-            ),
-            "package": [
-                {
-                    **package.dict(
-                        by_alias=True, exclude_unset=True, exclude_none=True
-                    ),
-                    "optional": (package.category != "main"),
-                }
-                for package in content.package
-            ],
-        }
-
+        output = content.to_v1().dict_for_output()
         yaml.dump(output, stream=f, sort_keys=False)

--- a/conda_lock/lockfile/v1/models.py
+++ b/conda_lock/lockfile/v1/models.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import typing
 
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from typing import TYPE_CHECKING, AbstractSet, ClassVar, Dict, List, Optional, Union
 
 
@@ -282,90 +282,3 @@ class Lockfile(StrictModel):
 
     package: List[LockedDependency]
     metadata: LockMeta
-
-    def __or__(self, other: "Lockfile") -> "Lockfile":
-        return other.__ror__(self)
-
-    def __ror__(self, other: "Optional[Lockfile]") -> "Lockfile":
-        """
-        merge self into other
-        """
-        if other is None:
-            return self
-        elif not isinstance(other, Lockfile):
-            raise TypeError
-
-        assert self.metadata.channels == other.metadata.channels
-
-        ours = {d.key(): d for d in self.package}
-        theirs = {d.key(): d for d in other.package}
-
-        # Pick ours preferentially
-        package: List[LockedDependency] = []
-        for key in sorted(set(ours.keys()).union(theirs.keys())):
-            if key not in ours or key[-1] not in self.metadata.platforms:
-                package.append(theirs[key])
-            else:
-                package.append(ours[key])
-
-        # Resort the conda packages topologically
-        final_package = self._toposort(package)
-        return Lockfile(package=final_package, metadata=other.metadata | self.metadata)
-
-    def toposort_inplace(self) -> None:
-        self.package = self._toposort(self.package)
-
-    @staticmethod
-    def _toposort(
-        package: List[LockedDependency], update: bool = False
-    ) -> List[LockedDependency]:
-        platforms = {d.platform for d in package}
-
-        # Resort the conda packages topologically
-        final_package: List[LockedDependency] = []
-        for platform in sorted(platforms):
-            from conda_lock._vendor.conda.common.toposort import toposort
-
-            # Add the remaining non-conda packages in the order in which they appeared.
-            # Order the pip packages topologically ordered (might be not 100% perfect if they depend on
-            # other conda packages, but good enough
-            for manager in ["conda", "pip"]:
-                lookup = defaultdict(set)
-                packages: Dict[str, LockedDependency] = {}
-
-                for d in package:
-                    if d.platform != platform:
-                        continue
-
-                    if d.manager != manager:
-                        continue
-
-                    lookup[d.name] = set(d.dependencies)
-                    packages[d.name] = d
-
-                ordered = toposort(lookup)
-                for package_name in ordered:
-                    # since we could have a pure dep in here, that does not have a package
-                    # eg a pip package that depends on a conda package (the conda package will not be in this list)
-                    dep = packages.get(package_name)
-                    if dep is None:
-                        continue
-                    if dep.manager != manager:
-                        continue
-                    # skip virtual packages
-                    if dep.manager == "conda" and dep.name.startswith("__"):
-                        continue
-
-                    final_package.append(dep)
-
-        return final_package
-
-
-class UpdateSpecification:
-    def __init__(
-        self,
-        locked: Optional[List[LockedDependency]] = None,
-        update: Optional[List[str]] = None,
-    ):
-        self.locked = locked or []
-        self.update = update or []

--- a/conda_lock/lockfile/v1/models.py
+++ b/conda_lock/lockfile/v1/models.py
@@ -324,7 +324,7 @@ class Lockfile(StrictModel):
         # Resort the conda packages topologically
         final_package: List[LockedDependency] = []
         for platform in sorted(platforms):
-            from .._vendor.conda.common.toposort import toposort
+            from conda_lock._vendor.conda.common.toposort import toposort
 
             # Add the remaining non-conda packages in the order in which they appeared.
             # Order the pip packages topologically ordered (might be not 100% perfect if they depend on

--- a/conda_lock/lockfile/v1/models.py
+++ b/conda_lock/lockfile/v1/models.py
@@ -36,7 +36,7 @@ class HashModel(StrictModel):
     sha256: Optional[str] = None
 
 
-class LockedDependency(StrictModel):
+class BaseLockedDependency(StrictModel):
     name: str
     version: str
     manager: Literal["conda", "pip"]
@@ -56,6 +56,10 @@ class LockedDependency(StrictModel):
         if (values["manager"] == "conda") and (v.md5 is None):
             raise ValueError("conda package hashes must use MD5")
         return v
+
+
+class LockedDependency(BaseLockedDependency):
+    optional: bool
 
 
 class MetadataOption(enum.Enum):

--- a/conda_lock/lockfile/v1/models.py
+++ b/conda_lock/lockfile/v1/models.py
@@ -1,12 +1,22 @@
 import datetime
 import enum
 import hashlib
+import json
 import logging
 import pathlib
 import typing
 
 from collections import namedtuple
-from typing import TYPE_CHECKING, AbstractSet, ClassVar, Dict, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Union,
+)
 
 
 if TYPE_CHECKING:
@@ -286,3 +296,16 @@ class Lockfile(StrictModel):
 
     package: List[LockedDependency]
     metadata: LockMeta
+
+    def dict_for_output(self) -> Dict[str, Any]:
+        """Convert the lockfile to a dictionary that can be written to a file."""
+        return {
+            "version": Lockfile.version,
+            "metadata": json.loads(
+                self.metadata.json(by_alias=True, exclude_unset=True, exclude_none=True)
+            ),
+            "package": [
+                package.dict(by_alias=True, exclude_unset=True, exclude_none=True)
+                for package in self.package
+            ],
+        }

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -2,15 +2,33 @@ from collections import defaultdict
 from typing import ClassVar, Dict, List, Optional
 
 from conda_lock.lockfile.v1.models import (
+    BaseLockedDependency,
     DependencySource,
     GitMeta,
     HashModel,
     InputMeta,
-    LockedDependency,
 )
+from conda_lock.lockfile.v1.models import LockedDependency as LockedDependencyV1
 from conda_lock.lockfile.v1.models import Lockfile as LockfileV1
 from conda_lock.lockfile.v1.models import LockMeta, MetadataOption, TimeMeta
 from conda_lock.models import StrictModel
+
+
+class LockedDependency(BaseLockedDependency):
+    def to_v1(self) -> LockedDependencyV1:
+        return LockedDependencyV1(
+            name=self.name,
+            version=self.version,
+            manager=self.manager,
+            platform=self.platform,
+            dependencies=self.dependencies,
+            url=self.url,
+            hash=self.hash,
+            category=self.category,
+            source=self.source,
+            build=self.build,
+            optional=self.category != "main",
+        )
 
 
 class Lockfile(StrictModel):
@@ -98,7 +116,7 @@ class Lockfile(StrictModel):
 
     def to_v1(self) -> LockfileV1:
         return LockfileV1(
-            package=self.package,
+            package=[p.to_v1() for p in self.package],
             metadata=self.metadata,
         )
 

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -121,6 +121,33 @@ class Lockfile(StrictModel):
         )
 
 
+def _locked_dependency_v1_to_v2(dep: LockedDependencyV1) -> LockedDependency:
+    """Convert a LockedDependency from v1 to v2.
+
+    * Remove the optional field (it is always equal to category != "main")
+    """
+    return LockedDependency(
+        name=dep.name,
+        version=dep.version,
+        manager=dep.manager,
+        platform=dep.platform,
+        dependencies=dep.dependencies,
+        url=dep.url,
+        hash=dep.hash,
+        category=dep.category,
+        source=dep.source,
+        build=dep.build,
+    )
+
+
+def lockfile_v1_to_v2(lockfile_v1: LockfileV1) -> Lockfile:
+    """Convert a Lockfile from v1 to v2."""
+    return Lockfile(
+        package=[_locked_dependency_v1_to_v2(p) for p in lockfile_v1.package],
+        metadata=lockfile_v1.metadata,
+    )
+
+
 class UpdateSpecification:
     def __init__(
         self,
@@ -142,4 +169,5 @@ __all__ = [
     "MetadataOption",
     "TimeMeta",
     "UpdateSpecification",
+    "lockfile_v1_to_v2",
 ]

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -1,0 +1,26 @@
+from conda_lock.lockfile.v1.models import (
+    DependencySource,
+    GitMeta,
+    HashModel,
+    InputMeta,
+    LockedDependency,
+    Lockfile,
+    LockMeta,
+    MetadataOption,
+    TimeMeta,
+    UpdateSpecification,
+)
+
+
+__all__ = [
+    "DependencySource",
+    "GitMeta",
+    "HashModel",
+    "InputMeta",
+    "LockedDependency",
+    "Lockfile",
+    "LockMeta",
+    "MetadataOption",
+    "TimeMeta",
+    "UpdateSpecification",
+]

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -1,15 +1,111 @@
+from collections import defaultdict
+from typing import ClassVar, Dict, List, Optional
+
 from conda_lock.lockfile.v1.models import (
     DependencySource,
     GitMeta,
     HashModel,
     InputMeta,
     LockedDependency,
-    Lockfile,
     LockMeta,
     MetadataOption,
     TimeMeta,
-    UpdateSpecification,
 )
+from conda_lock.models import StrictModel
+
+
+class Lockfile(StrictModel):
+    version: ClassVar[int] = 2
+
+    package: List[LockedDependency]
+    metadata: LockMeta
+
+    def __or__(self, other: "Lockfile") -> "Lockfile":
+        return other.__ror__(self)
+
+    def __ror__(self, other: "Optional[Lockfile]") -> "Lockfile":
+        """
+        merge self into other
+        """
+        if other is None:
+            return self
+        elif not isinstance(other, Lockfile):
+            raise TypeError
+
+        assert self.metadata.channels == other.metadata.channels
+
+        ours = {d.key(): d for d in self.package}
+        theirs = {d.key(): d for d in other.package}
+
+        # Pick ours preferentially
+        package: List[LockedDependency] = []
+        for key in sorted(set(ours.keys()).union(theirs.keys())):
+            if key not in ours or key[-1] not in self.metadata.platforms:
+                package.append(theirs[key])
+            else:
+                package.append(ours[key])
+
+        # Resort the conda packages topologically
+        final_package = self._toposort(package)
+        return Lockfile(package=final_package, metadata=other.metadata | self.metadata)
+
+    def toposort_inplace(self) -> None:
+        self.package = self._toposort(self.package)
+
+    @staticmethod
+    def _toposort(
+        package: List[LockedDependency], update: bool = False
+    ) -> List[LockedDependency]:
+        platforms = {d.platform for d in package}
+
+        # Resort the conda packages topologically
+        final_package: List[LockedDependency] = []
+        for platform in sorted(platforms):
+            from conda_lock._vendor.conda.common.toposort import toposort
+
+            # Add the remaining non-conda packages in the order in which they appeared.
+            # Order the pip packages topologically ordered (might be not 100% perfect if they depend on
+            # other conda packages, but good enough
+            for manager in ["conda", "pip"]:
+                lookup = defaultdict(set)
+                packages: Dict[str, LockedDependency] = {}
+
+                for d in package:
+                    if d.platform != platform:
+                        continue
+
+                    if d.manager != manager:
+                        continue
+
+                    lookup[d.name] = set(d.dependencies)
+                    packages[d.name] = d
+
+                ordered = toposort(lookup)
+                for package_name in ordered:
+                    # since we could have a pure dep in here, that does not have a package
+                    # eg a pip package that depends on a conda package (the conda package will not be in this list)
+                    dep = packages.get(package_name)
+                    if dep is None:
+                        continue
+                    if dep.manager != manager:
+                        continue
+                    # skip virtual packages
+                    if dep.manager == "conda" and dep.name.startswith("__"):
+                        continue
+
+                    final_package.append(dep)
+
+        return final_package
+
+
+class UpdateSpecification:
+    def __init__(
+        self,
+        locked: Optional[List[LockedDependency]] = None,
+        update: Optional[List[str]] = None,
+    ):
+        self.locked = locked or []
+        self.update = update or []
 
 
 __all__ = [

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -7,10 +7,9 @@ from conda_lock.lockfile.v1.models import (
     HashModel,
     InputMeta,
     LockedDependency,
-    LockMeta,
-    MetadataOption,
-    TimeMeta,
 )
+from conda_lock.lockfile.v1.models import Lockfile as LockfileV1
+from conda_lock.lockfile.v1.models import LockMeta, MetadataOption, TimeMeta
 from conda_lock.models import StrictModel
 
 
@@ -96,6 +95,12 @@ class Lockfile(StrictModel):
                     final_package.append(dep)
 
         return final_package
+
+    def to_v1(self) -> LockfileV1:
+        return LockfileV1(
+            package=self.package,
+            metadata=self.metadata,
+        )
 
 
 class UpdateSpecification:

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -24,7 +24,11 @@ from conda_lock._vendor.poetry.repositories.pypi_repository import PyPiRepositor
 from conda_lock._vendor.poetry.repositories.repository import Repository
 from conda_lock._vendor.poetry.utils.env import Env
 from conda_lock.lockfile import apply_categories
-from conda_lock.lockfile.v1.models import DependencySource, HashModel, LockedDependency
+from conda_lock.lockfile.v2prelim.models import (
+    DependencySource,
+    HashModel,
+    LockedDependency,
+)
 from conda_lock.lookup import conda_name_to_pypi_name
 from conda_lock.models import lock_spec
 

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -24,7 +24,7 @@ from conda_lock._vendor.poetry.repositories.pypi_repository import PyPiRepositor
 from conda_lock._vendor.poetry.repositories.repository import Repository
 from conda_lock._vendor.poetry.utils.env import Env
 from conda_lock.lockfile import apply_categories
-from conda_lock.lockfile.models import DependencySource, HashModel, LockedDependency
+from conda_lock.lockfile.v1.models import DependencySource, HashModel, LockedDependency
 from conda_lock.lookup import conda_name_to_pypi_name
 from conda_lock.models import lock_spec
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -56,7 +56,7 @@ from conda_lock.invoke_conda import (
     reset_conda_pkgs_dir,
 )
 from conda_lock.lockfile import parse_conda_lock_file
-from conda_lock.lockfile.models import HashModel, LockedDependency, MetadataOption
+from conda_lock.lockfile.v1.models import HashModel, LockedDependency, MetadataOption
 from conda_lock.models.channel import Channel
 from conda_lock.models.lock_spec import VersionedDependency
 from conda_lock.pypi_solver import parse_pip_requirement, solve_pypi

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -55,12 +55,8 @@ from conda_lock.invoke_conda import (
     is_micromamba,
     reset_conda_pkgs_dir,
 )
-from conda_lock.lockfile import (
-    HashModel,
-    LockedDependency,
-    MetadataOption,
-    parse_conda_lock_file,
-)
+from conda_lock.lockfile import parse_conda_lock_file
+from conda_lock.lockfile.models import HashModel, LockedDependency, MetadataOption
 from conda_lock.models.channel import Channel
 from conda_lock.models.lock_spec import VersionedDependency
 from conda_lock.pypi_solver import parse_pip_requirement, solve_pypi

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -56,7 +56,11 @@ from conda_lock.invoke_conda import (
     reset_conda_pkgs_dir,
 )
 from conda_lock.lockfile import parse_conda_lock_file
-from conda_lock.lockfile.v1.models import HashModel, LockedDependency, MetadataOption
+from conda_lock.lockfile.v2prelim.models import (
+    HashModel,
+    LockedDependency,
+    MetadataOption,
+)
 from conda_lock.models.channel import Channel
 from conda_lock.models.lock_spec import VersionedDependency
 from conda_lock.pypi_solver import parse_pip_requirement, solve_pypi


### PR DESCRIPTION
As described in #411, the merge of #389 broke parsing of lockfiles for the `conda-lock install` command due to a schema change.

In this PR I create explicit v1 and v2 schema, the v2 being preliminary. The only difference between the two is that v2 omits the `optional` from packages. There is no loss of information thanks to the invariant `optional = category != "main"`. Thus it's easy to convert between v1 and v2, and the corresponding functions are added here.

The combination of #389 and this PR should be a *pure refactor*, as input and output are done exclusively with the v1 schema.

This sets us up to make the schema modifiable, as there are some changes I'd like to make. (RFC coming soon...)

Before I consider this to be closing for #411, I want to add tests for `conda-lock install`. I merged #411 because the tests were green, despite the breakage, so I'd like to avoid this happening in the future.