### PR TITLE
use matchspec in LockedDependency creation (issue 414)

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -173,16 +173,23 @@ def solve_conda(
         return url
 
     # extract dependencies from package plan
-    planned = {
-        action["name"]: LockedDependency(
+    planned = {}
+    for action in dry_run_install["actions"]["FETCH"]:
+        dependencies = {}
+        for dep in action.get("depends") or []:
+            matchspec = MatchSpec(dep)
+            name = matchspec.name
+            version = (
+                matchspec.version.spec_str if matchspec.version is not None else ""
+            )
+            dependencies[name] = version
+
+        locked_dependency = LockedDependency(
             name=action["name"],
             version=action["version"],
             manager="conda",
             platform=platform,
-            dependencies={
-                item.split()[0]: " ".join(item.split(" ")[1:])
-                for item in action.get("depends") or []
-            },
+            dependencies=dependencies,
             # TODO: Normalize URL here and inject env vars
             url=normalize_url(action["url"]),
             # NB: virtual packages may have no hash
@@ -191,8 +198,7 @@ def solve_conda(
                 sha256=action.get("sha256"),
             ),
         )
-        for action in dry_run_install["actions"]["FETCH"]
-    }
+        planned[action["name"]] = locked_dependency
 
     # propagate categories from explicit to transitive dependencies
     apply_categories(


### PR DESCRIPTION
This addresses #414 



<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The previous implementation assumed that dependencies of installed packages listed in the dry-run-solve json output are of the format "\<name\> \<version\>", which is a subset of MatchSpec.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
