### PR TITLE
support nodefaults in environment.yml specs

### DIFF
--- a/conda_lock/src_parser/environment_yaml.py
+++ b/conda_lock/src_parser/environment_yaml.py
@@ -114,6 +114,11 @@ def parse_environment_file(
 
     env_yaml_data = yaml.safe_load(content)
     channels: List[str] = env_yaml_data.get("channels", [])
+    try:
+        # conda-lock will use `--override-channels` so nodefaults is redundant.
+        channels.remove("nodefaults")
+    except IndexError:
+        pass
 
     # These extension fields are nonstandard
     category: str = env_yaml_data.get("category") or "main"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -139,6 +139,11 @@ def filter_conda_environment(tmp_path: Path):
 
 
 @pytest.fixture
+def nodefaults_environment(tmp_path: Path):
+    return clone_test_dir("test-env-nodefaults", tmp_path).joinpath("environment.yml")
+
+
+@pytest.fixture
 def pip_environment(tmp_path: Path):
     return clone_test_dir("test-pypi-resolve", tmp_path).joinpath("environment.yml")
 
@@ -398,6 +403,11 @@ def test_parse_environment_file_with_pip(pip_environment: Path):
                 version="=0.9.1",
             )
         ]
+
+
+def test_parse_env_file_with_no_defaults(nodefaults_environment: Path):
+    res = parse_environment_file(nodefaults_environment, DEFAULT_PLATFORMS)
+    assert res.channels == [Channel.from_string("conda-forge")]
 
 
 def test_parse_env_file_with_filters_no_args(filter_conda_environment: Path):


### PR DESCRIPTION
### Description

conda environment.yml files [support](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-file-manually) a `- nodefaults` "channel" which suppresses the use of defaults channels in creating the environment. `conda-lock` uses `--override-channels` in the env creation anyway so `- nodefaults` is redundant but it causes a 404 error in the build since we treat `nodefaults` as a real channel. 

This fixes #192 