### PR TITLE
Add more pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,7 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403, F401
+ignore = E203, E266, E501, W503, F403, F401, C408
+# C408: I disagree since readability > speed:
+# <https://github.com/adamchainz/flake8-comprehensions/issues/418>
 max-line-length = 89
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,12 @@ repos:
   rev: 6.0.0
   hooks:
     - id: flake8
+      additional_dependencies:
+        - flake8-builtins
+        - flake8-comprehensions
+        - flake8-mutable
+        - flake8-use-fstring
+        - flake8-use-pathlib
 
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,11 @@ repos:
   - id: pyupgrade
     args: ["--py38-plus", "--keep-runtime-typing"]
 
+- repo: https://github.com/asottile/yesqa
+  rev: v1.4.0
+  hooks:
+  - id: yesqa
+
 - repo: https://github.com/psf/black
   rev: 23.3.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,12 @@ repos:
       exclude: "^.*\\.patch$"
     - id: check-ast
 
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.4.0
+  hooks:
+  - id: pyupgrade
+    args: ["--py38-plus", "--keep-runtime-typing"]
+
 - repo: https://github.com/psf/black
   rev: 23.3.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,11 @@ repos:
   - id: black
     language_version: python3
 
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.269
+  hooks:
+  - id: ruff
+
 - repo: https://github.com/pycqa/flake8
   rev: 6.0.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,8 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
+    - id: no-commit-to-branch
+      args: [--branch=main]
     - id: trailing-whitespace
       exclude: "^.*\\.patch$"
     - id: check-ast

--- a/conda_lock/click_helpers.py
+++ b/conda_lock/click_helpers.py
@@ -13,7 +13,7 @@ class OrderedGroup(DefaultGroup):
         commands: Optional[Mapping[str, click.Command]] = None,
         **kwargs: Any,
     ):
-        super(OrderedGroup, self).__init__(name, commands, **kwargs)
+        super().__init__(name, commands, **kwargs)
         #: the registered subcommands by their exported names.
         self.commands = commands or OrderedDict()
 

--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -46,7 +46,7 @@ def get_in(
 
 
 def read_file(filepath: Union[str, pathlib.Path]) -> str:
-    with open(filepath, mode="r") as fp:
+    with open(filepath) as fp:
         return fp.read()
 
 
@@ -71,7 +71,7 @@ def temporary_file_with_contents(content: str) -> Iterator[pathlib.Path]:
 
 
 def read_json(filepath: Union[str, pathlib.Path]) -> Dict:
-    with open(filepath, mode="r") as fp:
+    with open(filepath) as fp:
         return json.load(fp)
 
 

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -420,7 +420,7 @@ def do_render(
     """
     platforms = lockfile.metadata.platforms
     if override_platform is not None and len(override_platform) > 0:
-        platforms = list(sorted(set(platforms) & set(override_platform)))
+        platforms = sorted(set(platforms) & set(override_platform))
 
     if filename_template:
         if "{platform}" not in filename_template and len(platforms) > 1:
@@ -801,7 +801,7 @@ def create_lockfile_from_spec(
         package=[locked[k] for k in locked],
         metadata=LockMeta(
             content_hash=spec.content_hash(),
-            channels=[c for c in spec.channels],
+            channels=list(spec.channels),
             platforms=spec.platforms,
             sources=list(meta_sources.keys()),
             git_metadata=git_metadata,

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -21,6 +21,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
@@ -35,7 +36,6 @@ import pkg_resources
 import yaml
 
 from ensureconda.api import ensureconda
-from typing_extensions import Literal
 
 from conda_lock.click_helpers import OrderedGroup
 from conda_lock.common import (
@@ -1202,7 +1202,7 @@ def lock(
     if pypi_to_conda_lookup_file:
         set_lookup_location(pypi_to_conda_lookup_file)
 
-    metadata_enum_choices = set(MetadataOption(md) for md in metadata_choices)
+    metadata_enum_choices = {MetadataOption(md) for md in metadata_choices}
 
     metadata_yamls = [pathlib.Path(path) for path in metadata_yamls]
 

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -9,12 +9,19 @@ import tempfile
 import time
 
 from contextlib import contextmanager
-from typing import Dict, Iterable, Iterator, List, MutableSequence, Optional, Sequence
+from typing import (
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    MutableSequence,
+    Optional,
+    Sequence,
+    TypedDict,
+)
 from urllib.parse import urlsplit, urlunsplit
 
 import yaml
-
-from typing_extensions import TypedDict
 
 from conda_lock._vendor.conda.models.match_spec import MatchSpec
 from conda_lock.invoke_conda import (

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -353,8 +353,7 @@ def solve_specs_for_arch(
     proc = subprocess.run(
         [str(arg) for arg in args],
         env=conda_env_override(platform),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         encoding="utf8",
     )
 
@@ -479,8 +478,7 @@ def update_specs_for_arch(
                     for arg in args + ["-p", prefix, "--json", "--dry-run", *to_update]
                 ],
                 env=conda_env_override(platform),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 encoding="utf8",
             )
 

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -74,7 +74,7 @@ def apply_categories(
         return dep
 
     for name, request in requested.items():
-        todo: List[str] = list()
+        todo: List[str] = []
         deps: Set[str] = set()
         item = name
 

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -148,7 +148,7 @@ def write_conda_lock_file(
     content.toposort_inplace()
     with path.open("w") as f:
         if include_help_text:
-            categories = set(p.category for p in content.package)
+            categories = {p.category for p in content.package}
 
             def write_section(text: str) -> None:
                 lines = dedent(text).split("\n")

--- a/conda_lock/lockfile/v1/models.py
+++ b/conda_lock/lockfile/v1/models.py
@@ -22,8 +22,9 @@ from typing import (
 if TYPE_CHECKING:
     from hashlib import _Hash
 
+from typing import Literal
+
 from pydantic import Field, validator
-from typing_extensions import Literal
 
 from conda_lock.common import ordered_union, relative_path
 from conda_lock.models import StrictModel

--- a/conda_lock/lookup.py
+++ b/conda_lock/lookup.py
@@ -1,10 +1,8 @@
 from functools import cached_property
-from typing import Dict
+from typing import Dict, TypedDict
 
 import requests
 import yaml
-
-from typing_extensions import TypedDict
 
 
 class MappingEntry(TypedDict):

--- a/conda_lock/models/lock_spec.py
+++ b/conda_lock/models/lock_spec.py
@@ -3,10 +3,9 @@ import json
 import pathlib
 import typing
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, validator
-from typing_extensions import Literal
 
 from conda_lock.models import StrictModel
 from conda_lock.models.channel import Channel

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -228,7 +228,7 @@ def solve_pypi(
     installed = Repository()
     locked = Repository()
 
-    python_packages = dict()
+    python_packages = {}
     locked_dep: LockedDependency
     for locked_dep in conda_locked.values():
         if locked_dep.name.startswith("__"):

--- a/conda_lock/scripts/vendor_poetry/vendor_helpers.py
+++ b/conda_lock/scripts/vendor_poetry/vendor_helpers.py
@@ -427,7 +427,7 @@ def merge_requirements(
     relevant_requirements: list[Requirement],
 ) -> dict[str, Requirement]:
     merged_requirements: dict[str, Requirement] = {}
-    for req_name in set(req.name for req in relevant_requirements):
+    for req_name in {req.name for req in relevant_requirements}:
         # Simply concatenate the version specifiers.
         merged_specifiers = ",".join(
             req.version_requirements

--- a/conda_lock/scripts/vendor_poetry/vendor_helpers.py
+++ b/conda_lock/scripts/vendor_poetry/vendor_helpers.py
@@ -462,7 +462,7 @@ def merge_requirements(
             name=req_name,
             version_requirements=merged_specifiers,
             python_requirements=python_requirements,
-            sources=sorted(list(sources)),
+            sources=sorted(sources),
         )
     # Sort the merged requirements in alphabetical order
     merged_requirements = dict(sorted(merged_requirements.items()))

--- a/conda_lock/src_parser/meta_yaml.py
+++ b/conda_lock/src_parser/meta_yaml.py
@@ -60,7 +60,7 @@ class UndefinedNeverFail(jinja2.Undefined):
 
     # Unlike the methods above, Python requires that these
     # few methods must always return the correct type
-    __str__ = __repr__ = lambda self: self._return_value(str())  # type: ignore  # noqa: E731
+    __str__ = __repr__ = lambda self: self._return_value("")  # type: ignore  # noqa: E731
     __unicode__ = lambda self: self._return_value("")  # noqa: E731
     __int__ = lambda self: self._return_value(0)  # type: ignore  # noqa: E731
     __float__ = lambda self: self._return_value(0.0)  # type: ignore  # noqa: E731

--- a/conda_lock/src_parser/meta_yaml.py
+++ b/conda_lock/src_parser/meta_yaml.py
@@ -60,7 +60,7 @@ class UndefinedNeverFail(jinja2.Undefined):
 
     # Unlike the methods above, Python requires that these
     # few methods must always return the correct type
-    __str__ = __repr__ = lambda self: self._return_value("")  # type: ignore  # noqa: E731
+    __str__ = __repr__ = lambda self: self._return_value("")  # type: ignore
     __unicode__ = lambda self: self._return_value("")  # noqa: E731
     __int__ = lambda self: self._return_value(0)  # type: ignore  # noqa: E731
     __float__ = lambda self: self._return_value(0.0)  # type: ignore  # noqa: E731

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -148,7 +148,7 @@ def parse_poetry_pyproject_toml(
     # Support for poetry dependency groups as specified in
     # https://python-poetry.org/docs/managing-dependencies/#optional-groups
     for group_name, _ in get_in(["tool", "poetry", "group"], contents, {}).items():
-        group_key = tuple(["group", group_name, "dependencies"])
+        group_key = ("group", group_name, "dependencies")
         categories[group_key] = group_name
 
     default_non_conda_source = get_in(

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -25,7 +25,7 @@ if sys.version_info >= (3, 11):
 else:
     from tomli import load as toml_load
 
-from typing_extensions import Literal
+from typing import Literal
 
 from conda_lock.common import get_in
 from conda_lock.lookup import get_forward_lookup as get_lookup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "pyyaml >= 5.1",
     "ruamel.yaml",
     'tomli; python_version<"3.11"',
-    "typing-extensions",
     "toolz >=0.12.0,<1.0.0",
     "filelock >=3.8.0",
     # The following dependencies were added in the process of vendoring Poetry 1.1.15.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,6 @@ dependencies = [
     "crashtest >=0.3.0",
     # poetry:
     "html5lib >=1.0",
-    # poetry, poetry-core:
-    'importlib-metadata >=1.7.0; python_version <= "3.7"',
     # poetry:
     "keyring >=21.2.0",
     # poetry:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ flake8-max-line-length = 105
 flake8-ignore = ["docs/* ALL", "conda_lock/_version.py ALL"]
 filterwarnings = "ignore::DeprecationWarning"
 
+[tool.ruff]
+ignore = ["E501"]
+
 [tool.vendoring]
 destination = "conda_lock/_vendor"
 namespace = "conda_lock._vendor"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,8 @@ flake8
 flake8-builtins
 flake8-comprehensions
 flake8-mutable
+flake8-use-fstring
+flake8-use-pathlib
 build
 freezegun
 isort

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -109,12 +109,7 @@ def clone_test_dir(name: Union[str, List[str]], tmp_path: Path) -> Path:
     test_dir = TEST_DIR.joinpath(*name)
     assert test_dir.exists()
     assert test_dir.is_dir()
-    if sys.version_info >= (3, 8):
-        shutil.copytree(test_dir, tmp_path, dirs_exist_ok=True)
-    else:
-        from distutils.dir_util import copy_tree
-
-        copy_tree(str(test_dir), str(tmp_path))
+    shutil.copytree(test_dir, tmp_path, dirs_exist_ok=True)
     return tmp_path
 
 
@@ -880,12 +875,10 @@ def test_run_lock_with_input_metadata(
     run_lock(
         [zlib_environment],
         conda_exe=conda_exe,
-        metadata_choices=set(
-            [
-                MetadataOption.InputMd5,
-                MetadataOption.InputSha,
-            ]
-        ),
+        metadata_choices={
+            MetadataOption.InputMd5,
+            MetadataOption.InputSha,
+        },
     )
     lockfile = parse_conda_lock_file(zlib_environment.parent / DEFAULT_LOCKFILE_NAME)
 
@@ -917,11 +910,9 @@ def test_run_lock_with_time_metadata(
         run_lock(
             [zlib_environment],
             conda_exe=conda_exe,
-            metadata_choices=set(
-                [
-                    MetadataOption.TimeStamp,
-                ]
-            ),
+            metadata_choices={
+                MetadataOption.TimeStamp,
+            },
         )
     lockfile = parse_conda_lock_file(TIME_DIR / DEFAULT_LOCKFILE_NAME)
 
@@ -969,13 +960,11 @@ def test_run_lock_with_git_metadata(
     run_lock(
         [git_metadata_zlib_environment],
         conda_exe=conda_exe,
-        metadata_choices=set(
-            [
-                MetadataOption.GitSha,
-                MetadataOption.GitUserName,
-                MetadataOption.GitUserEmail,
-            ]
-        ),
+        metadata_choices={
+            MetadataOption.GitSha,
+            MetadataOption.GitUserName,
+            MetadataOption.GitUserEmail,
+        },
     )
     lockfile = parse_conda_lock_file(
         git_metadata_zlib_environment.parent / DEFAULT_LOCKFILE_NAME
@@ -1095,11 +1084,7 @@ def test_run_lock_with_locked_environment_files(
     make_lock_files = MagicMock()
     monkeypatch.setattr("conda_lock.conda_lock.make_lock_files", make_lock_files)
     run_lock(DEFAULT_FILES, conda_exe=conda_exe, update=["pydantic"])
-    if sys.version_info < (3, 8):
-        # backwards compat
-        src_files = make_lock_files.call_args_list[0][1]["src_files"]
-    else:
-        src_files = make_lock_files.call_args.kwargs["src_files"]
+    src_files = make_lock_files.call_args.kwargs["src_files"]
 
     assert [p.resolve() for p in src_files] == [
         Path(update_environment.parent / "environment-preupdate.yml")
@@ -1128,11 +1113,7 @@ def test_run_lock_relative_source_path(
     run_lock(
         DEFAULT_FILES, lockfile_path=lockfile, conda_exe=conda_exe, update=["pydantic"]
     )
-    if sys.version_info < (3, 8):
-        # backwards compat
-        src_files = make_lock_files.call_args_list[0][1]["src_files"]
-    else:
-        src_files = make_lock_files.call_args.kwargs["src_files"]
+    src_files = make_lock_files.call_args.kwargs["src_files"]
     assert [p.resolve() for p in src_files] == [environment.resolve()]
 
 
@@ -1639,7 +1620,7 @@ def test__extract_domain(line: str, stripped: str):
 
 
 def _read_file(filepath: "str | Path") -> str:
-    with open(filepath, mode="r") as file_pointer:
+    with open(filepath) as file_pointer:
         return file_pointer.read()
 
 


### PR DESCRIPTION
* `no-commit-to-branch` for `main` to enforce feature branches
* pyupgrade to keep style modern
* yesqa to remove redundant noqa comments
* ruff for fast linting
* flake8 plugins
        - flake8-builtins (already installed in dev dependencies)
        - flake8-comprehensions (already installed in dev dependencies)
        - flake8-mutable (already installed in dev dependencies)
        - flake8-use-fstring
        - flake8-use-pathlib

Also corresponding code cleanups to make everything pass.

Finally, eliminate dependencies on `importlib-metadata` and `typing_extensions`.