### PR TITLE
Use setup-micromamba for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,28 +23,29 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          miniforge-variant: Mambaforge
-          miniforge-version: 22.9.0-1
-          auto-update-conda: false
+          environment-name: test-env
+          init-shell: powershell
+          create-args: >-
+            python=3.11
+            mamba
+            pip
+            pytest-cov
+            pytest-xdist
 
       - name: Install dev deps
         run: |
-          conda activate test
-          mamba install pip pytest-cov pytest-xdist
           python -m pip install -r requirements-dev.txt
 
       - name: install conda-lock
         run: |
-          conda activate test
           pip install -e . --force-reinstall
 
       - name: run-test
         run: |
-          conda activate test
           copy pyproject.toml "%RUNNER_TEMP%"
           Xcopy /E /I tests "%RUNNER_TEMP%\\tests"
           pushd "${RUNNER_TEMP}"
@@ -70,18 +71,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          miniforge-variant: Mambaforge
-          miniforge-version: 22.9.0-1
-          auto-update-conda: false
+          environment-name: test-env
+          init-shell: bash
+          create-args: >-
+            python=${{ matrix.python-version }}
+            mamba
+            pip
+            pytest-cov
+            pytest-xdist
 
       - name: Install dev deps
         run: |
-          conda activate test
-          mamba install pip pytest-cov pytest-xdist
           set -x
           echo "${PATH}"
           which pip
@@ -91,14 +93,12 @@ jobs:
       - name: install conda-lock
         shell: bash -l {0}
         run: |
-          conda activate test
           which pip
           pip install -e . --force-reinstall
 
       - name: run-test
         shell: bash -l {0}
         run: |
-          conda activate test
           cp pyproject.toml "${RUNNER_TEMP}/"
           cp -a tests "${RUNNER_TEMP}/"
           pushd "${RUNNER_TEMP}"
@@ -113,7 +113,6 @@ jobs:
       - name: test-gdal
         shell: bash -l {0}
         run: |
-          conda activate test
           pushd "${RUNNER_TEMP}/tests/gdal"
           export TMPDIR="${RUNNER_TEMP}"
           ls -lah


### PR DESCRIPTION
The hope is that this will be quicker. It will also allow us to install dependencies in a single step.