### PR TITLE
Restore tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  MICROMAMBA_VERSION: '1.4.2-2'
+
 jobs:
   test-windows:
     env:
@@ -27,6 +30,7 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: ${{ env.MICROMAMBA_VERSION }}
           environment-name: test-env
           init-shell: powershell
           create-args: >-
@@ -73,6 +77,7 @@ jobs:
 
       - uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: ${{ env.MICROMAMBA_VERSION }}
           environment-name: test-env
           init-shell: bash
           create-args: >-

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -289,7 +289,7 @@ def include_dev_dependencies(request: Any) -> bool:
     params=[
         pytest.param("conda", marks=pytest.mark.skip(reason="slow")),
         pytest.param("mamba"),
-        pytest.param("micromamba", marks=pytest.mark.skip(reason="flaky, see #416")),
+        pytest.param("micromamba"),
     ],
 )
 def _conda_exe_type(request: Any) -> str:


### PR DESCRIPTION
In the process of releasing v2 in #419, we unfortunately had to disable micromamba tests in order to get the checks to pass.

The flaky tests are described in #416. I suspect it's an issue with newer versions of Micromamba.

Thus I'm reenabling the Micromamba tests and pinning Micromamba in hopes of bisecting the problem.