### PR TITLE
Handle nodefaults correctly in all specs

### DIFF
--- a/conda_lock/models/lock_spec.py
+++ b/conda_lock/models/lock_spec.py
@@ -81,5 +81,8 @@ class LockSpecification(BaseModel):
     def validate_channels(cls, v: List[Union[Channel, str]]) -> List[Channel]:
         for i, e in enumerate(v):
             if isinstance(e, str):
-                v[i] = Channel.from_string(e)
+                e = Channel.from_string(e)
+                v[i] = e
+            if e.url == "nodefaults":
+                raise ValueError("nodefaults channel is not allowed, ref #418")
         return typing.cast(List[Channel], v)

--- a/conda_lock/src_parser/meta_yaml.py
+++ b/conda_lock/src_parser/meta_yaml.py
@@ -103,6 +103,11 @@ def parse_meta_yaml_file(
         meta_yaml_data = yaml.safe_load(rendered)
 
     channels = get_in(["extra", "channels"], meta_yaml_data, [])
+    try:
+        # conda-lock will use `--override-channels` so nodefaults is redundant.
+        channels.remove("nodefaults")
+    except ValueError:
+        pass
 
     # parse with selectors for each target platform
     dep_map = {

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -299,9 +299,16 @@ def specification_with_dependencies(
             if dep.name in force_pypi:
                 dep.manager = "pip"
 
+    channels = get_in(["tool", "conda-lock", "channels"], toml_contents, [])
+    try:
+        # conda-lock will use `--override-channels` so nodefaults is redundant.
+        channels.remove("nodefaults")
+    except ValueError:
+        pass
+
     return LockSpecification(
         dependencies={platform: dependencies for platform in platforms},
-        channels=get_in(["tool", "conda-lock", "channels"], toml_contents, []),
+        channels=channels,
         sources=[path],
         allow_pypi_requests=get_in(
             ["tool", "conda-lock", "allow-pypi-requests"], toml_contents, True


### PR DESCRIPTION
The solution in #418 missed the potential specification of `nodefaults` in `meta.yaml` and `pyproject.toml` files. This aims to handle those cases.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->



<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
