### PR TITLE
Allow the use of channels like `channel::package` in TOML files.

### DIFF
--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -279,13 +279,22 @@ def specification_with_dependencies(
     ).items():
         if isinstance(depattrs, str):
             conda_version = depattrs
+            channel_split = depname.split("::")
+            if len(channel_split) == 1:
+                channel = None
+                name = channel_split[0]
+            else:
+                channel = channel_split[0]
+                name = channel_split[1]
+
             dependencies.append(
                 VersionedDependency(
-                    name=depname,
+                    name=name,
                     version=conda_version,
                     manager="conda",
                     category="main",
                     extras=[],
+                    conda_channel=channel,
                 )
             )
         elif isinstance(depattrs, collections.abc.Mapping):

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -35,6 +35,7 @@ from conda_lock.models.lock_spec import (
     URLDependency,
     VersionedDependency,
 )
+from conda_lock.src_parser.conda_common import conda_spec_to_versioned_dep
 
 
 POETRY_INVALID_EXTRA_LOC = (
@@ -278,24 +279,8 @@ def specification_with_dependencies(
         ["tool", "conda-lock", "dependencies"], toml_contents, {}
     ).items():
         if isinstance(depattrs, str):
-            conda_version = depattrs
-            channel_split = depname.split("::")
-            if len(channel_split) == 1:
-                channel = None
-                name = channel_split[0]
-            else:
-                channel = channel_split[0]
-                name = channel_split[1]
-
             dependencies.append(
-                VersionedDependency(
-                    name=name,
-                    version=conda_version,
-                    manager="conda",
-                    category="main",
-                    extras=[],
-                    conda_channel=channel,
-                )
+                conda_spec_to_versioned_dep(f"{depname} {depattrs}", "main")
             )
         elif isinstance(depattrs, collections.abc.Mapping):
             if depattrs.get("source", None) == "pypi":

--- a/tests/test-toml-channel/pyproject.toml
+++ b/tests/test-toml-channel/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "conda-lock-test-poetry-optional"
+version = "0.0.1"
+description = ""
+authors = ["conda-lock"]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.conda-lock]
+platforms = ["linux-64"]
+channels = ["conda-forge"]
+
+[tool.conda-lock.dependencies]
+"comet_ml::comet_ml" = "3.32.0"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -241,6 +241,11 @@ def pdm_pyproject_toml_default_pip(tmp_path: Path):
 
 
 @pytest.fixture
+def pyproject_channel_toml(tmp_path: Path):
+    return clone_test_dir("test-toml-channel", tmp_path).joinpath("pyproject.toml")
+
+
+@pytest.fixture
 def channel_inversion(tmp_path: Path):
     """Path to an environment.yaml that has a hardcoded channel in one of the dependencies"""
     return clone_test_dir("test-channel-inversion", tmp_path).joinpath(
@@ -830,6 +835,17 @@ def test_parse_pdm_default_pip(pdm_pyproject_toml_default_pip: Path):
     assert specs["click"].manager == "pip"
 
 
+def test_parse_pyproject_channel_toml(pyproject_channel_toml: Path):
+    res = parse_pyproject_toml(pyproject_channel_toml, ["linux-64"])
+
+    specs = {
+        dep.name: typing.cast(VersionedDependency, dep)
+        for dep in res.dependencies["linux-64"]
+    }
+
+    assert specs["comet_ml"].manager == "conda"
+
+
 def test_parse_poetry_invalid_optionals(pyproject_optional_toml: Path):
     filename = pyproject_optional_toml.name
 
@@ -869,6 +885,15 @@ def test_run_lock(
     if is_micromamba(conda_exe):
         monkeypatch.setenv("CONDA_FLAGS", "-v")
     run_lock([zlib_environment], conda_exe=conda_exe)
+
+
+def test_run_lock_channel_toml(
+    monkeypatch: "pytest.MonkeyPatch", pyproject_channel_toml: Path, conda_exe: str
+):
+    monkeypatch.chdir(pyproject_channel_toml.parent)
+    if is_micromamba(conda_exe):
+        monkeypatch.setenv("CONDA_FLAGS", "-v")
+    run_lock([pyproject_channel_toml], conda_exe=conda_exe)
 
 
 def test_run_lock_with_input_metadata(


### PR DESCRIPTION
This functionality worked for environment.yml type of files but was broken for TOML files.

### Description

Small change to allow the use of `channel::package` in the `tool.conda-lock.dependencies` section of TOML files.

A test is included. The test fails before this PR and succeeds after. The test specifically includes a package that is available on the channel specified but *not* on the default conda-forge channel.
