### PR TITLE
Change to temp directory for running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import re
+import tempfile
 
 from typing import Iterable, NamedTuple
 
@@ -114,3 +115,14 @@ def test_quetz(quetz_server: QuetzServerInfo) -> None:
     assert (
         channel["mirror_channel_url"] == "https://conda-static.anaconda.org/conda-forge"
     )
+
+
+@pytest.fixture(autouse=True)
+def chdir_to_temp_dir() -> Iterable[str]:
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        old_dir = os.getcwd()
+        os.chdir(tmpdirname)
+        try:
+            yield tmpdirname
+        finally:
+            os.chdir(old_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,12 +117,13 @@ def test_quetz(quetz_server: QuetzServerInfo) -> None:
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="session")
 def chdir_to_temp_dir() -> Iterable[str]:
     with tempfile.TemporaryDirectory() as tmpdirname:
         old_dir = os.getcwd()
         os.chdir(tmpdirname)
         try:
             yield tmpdirname
+            assert not os.listdir(tmpdirname)
         finally:
             os.chdir(old_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,10 @@ def chdir_to_temp_dir() -> Iterable[str]:
         try:
             yield tmpdirname
         finally:
+            os.chdir(old_dir)
+            # It's important that we changed the directory back before calling assert.
+            # In case the assert fails, then the chdir won't run, and then cleanup
+            # can't proceed on Windows because you can't delete the current working
+            # directory.
             leftover_files = os.listdir(tmpdirname)
             assert leftover_files == [], f"Test didn't clean up files: {leftover_files}"
-            os.chdir(old_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,13 +117,14 @@ def test_quetz(quetz_server: QuetzServerInfo) -> None:
     )
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True)
 def chdir_to_temp_dir() -> Iterable[str]:
     with tempfile.TemporaryDirectory() as tmpdirname:
         old_dir = os.getcwd()
         os.chdir(tmpdirname)
         try:
             yield tmpdirname
-            assert not os.listdir(tmpdirname)
         finally:
+            leftover_files = os.listdir(tmpdirname)
+            assert leftover_files == [], f"Test didn't clean up files: {leftover_files}"
             os.chdir(old_dir)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.xfail(
+    reason="This test should fail because it leaves a file behind.",
+    raises=AssertionError,
+)
+def test_cleanup() -> None:
+    with open("leftover.txt", "w") as f:
+        f.write("This file is left behind.")


### PR DESCRIPTION
Conda-lock is sensitive to files in the current directory. Using it from the project root risks conflicts, like in #359 where I'd like to add a `conda-lock.yml`. Thus it may be desirable to run from an isolated directory by default.