### PR TITLE
warn if cuda packages are installed implicitly

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -133,7 +133,7 @@ KIND_USE_TEXT = {
 _implicit_cuda_message = """
   'cudatoolkit' package added implicitly without specifying that cuda packages
   should be accepted.
-  Add a minimum cuda version via `--with-cuda VERSION` or via virtual packages
+  Specify a cuda version via `--with-cuda VERSION` or via virtual packages
   to suppress this warning,
   or pass `--without-cuda` to explicitly exclude cuda packages.
 """

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -302,17 +302,20 @@ def make_lock_files(  # noqa: C901
         YAML or JSON file(s) containing structured metadata to add to metadata section of the lockfile.
     """
 
-    cuda_specified = True
     # initialize virtual packages
     if virtual_package_spec and virtual_package_spec.exists():
         virtual_package_repo = virtual_package_repo_from_specification(
             virtual_package_spec
         )
+        cuda_specified = True
     else:
-        cuda_specified = with_cuda is not None
-        if not cuda_specified:
+        if with_cuda is None:
+            cuda_specified = False
             with_cuda = "11.4"
-        virtual_package_repo = default_virtual_package_repodata(with_cuda=with_cuda)
+        else:
+            cuda_specified = True
+
+        virtual_package_repo = default_virtual_package_repodata(cuda_version=with_cuda)
 
     required_categories = {"main"}
     if include_dev_dependencies:

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -309,9 +309,8 @@ def make_lock_files(  # noqa: C901
             virtual_package_spec
         )
     else:
-        if with_cuda is None:
-            cuda_specified = False
-            # the default version if cuda is unspecified
+        cuda_specified = with_cuda is not None
+        if not cuda_specified:
             with_cuda = "11.4"
         virtual_package_repo = default_virtual_package_repodata(with_cuda=with_cuda)
 

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -241,7 +241,7 @@ def fn_to_dist_name(fn: str) -> str:
     return fn
 
 
-def make_lock_files(
+def make_lock_files(  # noqa: C901
     *,
     conda: PathLike,
     src_files: List[pathlib.Path],

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -172,7 +172,7 @@ OSX_VERSIONS_X68_ARM64 = ["11.0"]
 OSX_VERSIONS_ARM64: List[str] = []
 
 
-def default_virtual_package_repodata(with_cuda: Optional[bool] = None) -> FakeRepoData:
+def default_virtual_package_repodata(with_cuda: str = "11.4") -> FakeRepoData:
     """Define a reasonable modern set of virtual packages that should be safe enough to assume"""
     repodata = _init_fake_repodata()
 
@@ -211,11 +211,11 @@ def default_virtual_package_repodata(with_cuda: Optional[bool] = None) -> FakeRe
         glibc_virtual, subdirs=["linux-aarch64", "linux-ppc64le", "linux-64"]
     )
 
-    if with_cuda in {None, True}:
+    if with_cuda:
         # default value
-        cuda_versions = ["11.4"]
+        cuda_versions = [with_cuda]
     else:
-        # opt-out
+        # opt-out with falsy empty version string or None
         cuda_versions = []
 
     for cuda_version in cuda_versions:

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -172,7 +172,7 @@ OSX_VERSIONS_X68_ARM64 = ["11.0"]
 OSX_VERSIONS_ARM64: List[str] = []
 
 
-def default_virtual_package_repodata() -> FakeRepoData:
+def default_virtual_package_repodata(with_cuda: Optional[bool] = None) -> FakeRepoData:
     """Define a reasonable modern set of virtual packages that should be safe enough to assume"""
     repodata = _init_fake_repodata()
 
@@ -211,7 +211,14 @@ def default_virtual_package_repodata() -> FakeRepoData:
         glibc_virtual, subdirs=["linux-aarch64", "linux-ppc64le", "linux-64"]
     )
 
-    for cuda_version in ["11.4"]:
+    if with_cuda in {None, True}:
+        # default value
+        cuda_versions = ["11.4"]
+    else:
+        # opt-out
+        cuda_versions = []
+
+    for cuda_version in cuda_versions:
         cuda_virtual = FakePackage(name="__cuda", version=cuda_version)
         repodata.add_package(
             cuda_virtual,

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -172,7 +172,8 @@ OSX_VERSIONS_X68_ARM64 = ["11.0"]
 OSX_VERSIONS_ARM64: List[str] = []
 
 
-def default_virtual_package_repodata(with_cuda: str = "11.4") -> FakeRepoData:
+def default_virtual_package_repodata(cuda_version: str = "11.4") -> FakeRepoData:
+    """An empty cuda_version indicates that CUDA is unavailable."""
     """Define a reasonable modern set of virtual packages that should be safe enough to assume"""
     repodata = _init_fake_repodata()
 
@@ -211,14 +212,7 @@ def default_virtual_package_repodata(with_cuda: str = "11.4") -> FakeRepoData:
         glibc_virtual, subdirs=["linux-aarch64", "linux-ppc64le", "linux-64"]
     )
 
-    if with_cuda:
-        # default value
-        cuda_versions = [with_cuda]
-    else:
-        # opt-out with falsy empty version string or None
-        cuda_versions = []
-
-    for cuda_version in cuda_versions:
+    if cuda_version != "":
         cuda_virtual = FakePackage(name="__cuda", version=cuda_version)
         repodata.add_package(
             cuda_virtual,


### PR DESCRIPTION
closes #426 

doesn't change default behavior, but adds a warning if cuda is not requested but 'cudatoolkit' is pulled in, as suggested by @maresb. The presence of 'cudatoolkit' itself in the dependency list is considered sufficient for an 'explicit cuda' signal.

I could leave out that condition because the available version is still implicit, which may trip folks up.

I initially wanted to allow specifying a version with `--with-cuda [version]`, but click doesn't seem to want folks to have options with 0 or 1 args. Plus, virtual package specs already solve this, so it's not worth the fight with click.