### PR TITLE
List prefixes for consideration for env var substitution

### DIFF
--- a/docs/authenticated_channels.md
+++ b/docs/authenticated_channels.md
@@ -112,7 +112,7 @@ package:
   version: 22.02.00
 ```
 
-Note however that the rendered lockfiles (` --kind explicit`) will contain substituted environment variables, so if you are making use of `conda-lock`
+Note however that the rendered lockfiles (`--kind explicit`) will contain substituted environment variables, so if you are making use of `conda-lock`
 in conjunction with git these should **NOT** be checked into version control.
 
 [anaconda.org]: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually

--- a/docs/authenticated_channels.md
+++ b/docs/authenticated_channels.md
@@ -78,7 +78,7 @@ Since we can generally assume that these substitutions are both volatile _and_ s
 the raw version of a url in the unified lockfile.
 
 If it encounters a channel url that looks as if it contains a credential portion (see below) it will search the currently
-available environment variables for a match with that variable. 
+available environment variables for a match with that variable.
 
 `conda-lock` will identify the following environment variables as containing credentials only if they have these *suffixes*:
 

--- a/docs/authenticated_channels.md
+++ b/docs/authenticated_channels.md
@@ -77,23 +77,40 @@ Additionally simple auth also support the [--strip-auth, --auth and --auth-file]
 Since we can generally assume that these substitutions are both volatile _and_ secret `conda-lock` will not store
 the raw version of a url in the unified lockfile.
 
-If it encounters a channel url that looks as if it contains a credential portion it will search the currently
-available environment variables for a match with that variable.  In the case of a match that portion of the url
-will be replaced with a environment variable.
+If it encounters a channel url that looks as if it contains a credential portion (see below) it will search the currently
+available environment variables for a match with that variable. 
 
-??? example "Example output in unified lockfile"
+`conda-lock` will identify the following environment variables as containing credentials only if they have these *suffixes*:
 
-    ```yaml
-    metadata:
-    channels:
-    - url: https://host.tld/t/$QUETZ_API_KEY/channel_name
-        used_env_vars:
-        - QUETZ_API_KEY
-    package:
-    - platform: linux-64
-    url: https://host.tld/t/$QUETZ_API_KEY/channel_name/linux-64/libsomethingprivate-22.02.00.tar.bz2
-    version: 22.02.00
-    ```
+* User names: `["USERNAME", "USER"]`.
+* Passwords: `["PASSWORD", "PASS", "TOKEN", "KEY"]`.
+* Tokens: `["TOKEN", "CRED", "PASSWORD", "PASS", "KEY"]`.
+
+In the case of a match that portion of the url will be replaced with a environment variable.
+
+For example using this configuration in your `environment.yml`:
+
+```yaml
+channels:
+    - https://host.tld/t/$QUETZ_API_KEY/channel_name
+    - conda-forge
+```
+
+Will result in this lock file:
+
+```yaml
+metadata:
+  channels:
+  - url: https://host.tld/t/$QUETZ_API_KEY/channel_name
+    used_env_vars:
+    - QUETZ_API_KEY
+  - url: conda-forge
+    used_env_vars: []
+package:
+- platform: linux-64
+  url: https://host.tld/t/$QUETZ_API_KEY/channel_name/linux-64/libsomethingprivate-22.02.00.tar.bz2
+  version: 22.02.00
+```
 
 The rendered lockfiles will contain substituted environment variables, so if you are making use of `conda-lock`
 in conjunction with git these should _NOT_ be checked into version control.

--- a/docs/authenticated_channels.md
+++ b/docs/authenticated_channels.md
@@ -112,7 +112,7 @@ package:
   version: 22.02.00
 ```
 
-The rendered lockfiles will contain substituted environment variables, so if you are making use of `conda-lock`
-in conjunction with git these should _NOT_ be checked into version control.
+Note however that the rendered lockfiles (` --kind explicit`) will contain substituted environment variables, so if you are making use of `conda-lock`
+in conjunction with git these should **NOT** be checked into version control.
 
 [anaconda.org]: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually

--- a/docs/authenticated_channels.md
+++ b/docs/authenticated_channels.md
@@ -86,7 +86,7 @@ available environment variables for a match with that variable.
 * Passwords: `["PASSWORD", "PASS", "TOKEN", "KEY"]`.
 * Tokens: `["TOKEN", "CRED", "PASSWORD", "PASS", "KEY"]`.
 
-In the case of a match that portion of the url will be replaced with a environment variable.
+In the case of a match that portion of the url will be replaced with an environment variable.
 
 For example using this configuration in your `environment.yml`:
 


### PR DESCRIPTION
This explicitly lists the prefixes used by conda-lock to detect and use environment variables to replace sensitive variables in lock files, taken from here:

https://github.com/conda/conda-lock/blob/60991f485f5711462b574a290ce7000e40aa0b9d/conda_lock/models/channel.py#L198-L226C20

