### PR TITLE
Create macOS platform tags using packaging 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,16 @@ repos:
     args: ["--profile", "black", "--filter-files"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.2.0
+  rev: v1.4.1
   hooks:
   - id: mypy
-    additional_dependencies: [types-filelock, types-requests, types-toml, types-PyYAML, types-freezegun, types-setuptools, pydantic]
+    additional_dependencies:
+      - types-filelock
+      - types-requests
+      - types-toml
+      - types-PyYAML
+      - pytest
+      - types-freezegun
+      - types-setuptools
+      - pydantic
     exclude: ^(tests/test-local-pip/setup.py$|tests/test_conda_lock.py)

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -979,7 +979,7 @@ def _render_lockfile_for_install(
 def run_lock(
     environment_files: List[pathlib.Path],
     *,
-    conda_exe: Optional[str],
+    conda_exe: Optional[PathLike],
     platforms: Optional[List[str]] = None,
     mamba: bool = False,
     micromamba: bool = False,

--- a/conda_lock/invoke_conda.py
+++ b/conda_lock/invoke_conda.py
@@ -40,7 +40,7 @@ def _ensureconda(
 
 
 def _determine_conda_executable(
-    conda_executable: Optional[str], mamba: bool, micromamba: bool
+    conda_executable: Optional[PathLike], mamba: bool, micromamba: bool
 ) -> Iterator[Optional[PathLike]]:
     if conda_executable:
         if pathlib.Path(conda_executable).exists():
@@ -51,7 +51,7 @@ def _determine_conda_executable(
 
 
 def determine_conda_executable(
-    conda_executable: Optional[str], mamba: bool, micromamba: bool
+    conda_executable: Optional[PathLike], mamba: bool, micromamba: bool
 ) -> PathLike:
     for candidate in _determine_conda_executable(conda_executable, mamba, micromamba):
         if candidate is not None:

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -51,18 +51,16 @@ class PlatformEnv(Env):
 
     def __init__(self, python_version: str, platform: str):
         super().__init__(path=Path(sys.prefix))
-        if platform.startswith("linux-"):
-            arch = platform.split("-")[-1]
-            if arch == "64":
-                arch = "x86_64"
+        system, arch = platform.split("-")
+        if arch == "64":
+            arch = "x86_64"
+
+        if system == "linux":
             self._platforms = [
                 f"manylinux{tag}_{arch}" for tag in reversed(MANYLINUX_TAGS)
             ]
             self._platforms.append(f"linux_{arch}")
-        elif platform.startswith("osx"):
-            arch = platform.split("-")[-1]
-            if arch == "64":
-                arch = "x86_64"
+        elif system == "osx":
             self._platforms = list(mac_platforms(MACOS_VERSION, arch))
         elif platform == "win-64":
             self._platforms = ["win_amd64"]
@@ -70,15 +68,15 @@ class PlatformEnv(Env):
             raise ValueError(f"Unsupported platform '{platform}'")
         self._python_version = tuple(map(int, python_version.split(".")))
 
-        if platform.startswith("osx-"):
+        if system == "osx":
             self._sys_platform = "darwin"
             self._platform_system = "Darwin"
             self._os_name = "posix"
-        elif platform.startswith("linux-"):
+        elif system == "linux":
             self._sys_platform = "linux"
             self._platform_system = "Linux"
             self._os_name = "posix"
-        elif platform.startswith("win-"):
+        elif system == "win":
             self._sys_platform = "win32"
             self._platform_system = "Windows"
             self._os_name = "nt"

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -7,7 +7,7 @@ from urllib.parse import urldefrag
 
 from clikit.api.io.flags import VERY_VERBOSE
 from clikit.io import ConsoleIO, NullIO
-from packaging.tags import compatible_tags, cpython_tags
+from packaging.tags import compatible_tags, cpython_tags, mac_platforms
 
 from conda_lock._vendor.poetry.core.packages import Dependency as PoetryDependency
 from conda_lock._vendor.poetry.core.packages import Package as PoetryPackage
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 
 # NB: in principle these depend on the glibc in the conda env
 MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17"]
+# This needs to be updated periodically as new macOS versions are released.
+MACOS_VERSION = (13, 4)
 
 
 class PlatformEnv(Env):
@@ -57,17 +59,11 @@ class PlatformEnv(Env):
                 f"manylinux{tag}_{arch}" for tag in reversed(MANYLINUX_TAGS)
             ]
             self._platforms.append(f"linux_{arch}")
-        elif platform == "osx-64":
-            self._platforms = [
-                "macosx_10_9_x86_64",
-                *(f"macosx_10_{version}_universal2" for version in range(16, 3, -1)),
-                *(f"macosx_10_{version}_universal" for version in range(16, 3, -1)),
-            ]
-        elif platform == "osx-arm64":
-            self._platforms = [
-                "macosx_11_0_arm64",
-                *(f"macosx_10_{version}_universal2" for version in range(16, 3, -1)),
-            ]
+        elif platform.startswith("osx"):
+            arch = platform.split("-")[-1]
+            if arch == "64":
+                arch = "x86_64"
+            self._platforms = list(mac_platforms(MACOS_VERSION, arch))
         elif platform == "win-64":
             self._platforms = ["win_amd64"]
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import re
 
-from typing import Iterable, NamedTuple
+from typing import Iterable, NamedTuple, NoReturn
 
 import docker
 import pytest
@@ -10,6 +10,23 @@ import requests
 
 from docker.models.containers import Container
 from ensureconda.resolve import platform_subdir
+
+from conda_lock.invoke_conda import _ensureconda
+
+
+@pytest.fixture(scope="session")
+def mamba_exe() -> pathlib.Path:
+    """Provides a fixture for tests that require mamba"""
+    kwargs = dict(
+        mamba=True,
+        micromamba=False,
+        conda=False,
+        conda_exe=False,
+    )
+    _conda_exe = _ensureconda(**kwargs)
+    if _conda_exe is not None:
+        return _conda_exe
+    pytest.skip("mamba is not installed")
 
 
 class QuetzServerInfo(NamedTuple):

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -1537,21 +1537,6 @@ def test_conda_pip_regressions_gh290(
     run_lock([spec], conda_exe=mamba_exe)
 
 
-@pytest.fixture(scope="session")
-def mamba_exe():
-    """Provides a fixture for tests that require mamba"""
-    kwargs = dict(
-        mamba=True,
-        micromamba=False,
-        conda=False,
-        conda_exe=False,
-    )
-    _conda_exe = _ensureconda(**kwargs)
-    if _conda_exe is not None:
-        return _conda_exe
-    pytest.skip("mamba is not installed")
-
-
 def _check_package_installed(package: str, prefix: str):
     import glob
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,29 @@
+"""This is a test module to ensure that the various changes we've made over time don't
+break the functionality of conda-lock.  This is a regression test suite."""
+
+import textwrap
+
+from pathlib import Path
+
+import pytest
+
+from conda_lock.conda_lock import run_lock
+
+
+@pytest.mark.parametrize("platform", ["linux-64", "osx-64", "osx-arm64"])
+def test_pr_436(
+    mamba_exe: Path, monkeypatch: "pytest.MonkeyPatch", tmp_path: Path, platform: str
+) -> None:
+    """Ensure that we can lock this environment which requires more modern osx path selectors"""
+    spec = textwrap.dedent(
+        """
+        channels:
+        - conda-forge
+        dependencies:
+        - pip:
+            - drjit
+        """
+    )
+    (tmp_path / "environment.yml").write_text(spec)
+    monkeypatch.chdir(tmp_path)
+    run_lock([tmp_path / "environment.yml"], conda_exe=mamba_exe, platforms=[platform])


### PR DESCRIPTION
### Description

Populate the list of supported platforms tags for the macOS platform using the `mac_platforms` function in packaging.tags.  This given a complete listing of platform tags which is also used by pip.  

This avoiding the need to periodically update a static listing of tags.  The new `MACOS_VERSION` variable will need to be updated periodically to reflect the latest version of macOS.

Likely fixes #403 and #436