### PR TITLE
Update helptext to describe new default unified lock file name

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1239,7 +1239,10 @@ def lock(
 ) -> None:
     """Generate fully reproducible lock files for conda environments.
 
-    By default, the lock files are written to conda-{platform}.lock. These filenames can be customized using the
+    By default, a multi-platform lock file is written to conda-lock.yml.
+
+    When choosing the "explicit" or "env" kind, lock files are written to
+    conda-{platform}.lock. These filenames can be customized using the
     --filename-template argument. The following tokens are available:
 
     \b


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I found the helptext for the `lock` subcommand was out-of-date in the way it described its default behavior. The new text is better aligned with the [README](https://github.com/conda/conda-lock#file-naming).

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
