### PR TITLE
Move other regression tests to test_regression

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,13 +1,21 @@
 [mypy]
 plugins = pydantic.mypy
-disallow_untyped_defs = true
 # disallow_untyped_calls = true
 # disallow_untyped_decorators = false
-disallow_incomplete_defs = true
+disallow_untyped_defs = false
+disallow_untyped_calls = false
+disallow_untyped_decorators = false
+disallow_incomplete_defs = false
 check_untyped_defs = true
 exclude = (?x)(
     tests/test-local-pip/setup.py
   )
+
+[mypy-conda_lock.*]
+disallow_untyped_defs = true
+# disallow_untyped_calls = true
+# disallow_untyped_decorators = true
+disallow_incomplete_defs = true
 
 [pydantic-mypy]
 init_forbid_extra = True
@@ -36,8 +44,4 @@ ignore_missing_imports = True
 [mypy-click_default_group.*]
 ignore_missing_imports = True
 
-[mypy-test_conda_lock]
-disallow_untyped_defs = false
-disallow_untyped_calls = false
-disallow_untyped_decorators = false
-disallow_incomplete_defs = false
+[mypy-tests.*]

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,13 +1,35 @@
 """This is a test module to ensure that the various changes we've made over time don't
 break the functionality of conda-lock.  This is a regression test suite."""
 
+import shutil
+import sys
 import textwrap
 
 from pathlib import Path
+from typing import List, Union
 
 import pytest
 
 from conda_lock.conda_lock import run_lock
+from conda_lock.invoke_conda import is_micromamba
+
+
+TEST_DIR = Path(__file__).parent
+
+
+def clone_test_dir(name: Union[str, List[str]], tmp_path: Path) -> Path:
+    if isinstance(name, str):
+        name = [name]
+    test_dir = TEST_DIR.joinpath(*name)
+    assert test_dir.exists()
+    assert test_dir.is_dir()
+    if sys.version_info >= (3, 8):
+        shutil.copytree(test_dir, tmp_path, dirs_exist_ok=True)
+    else:
+        from distutils.dir_util import copy_tree
+
+        copy_tree(str(test_dir), str(tmp_path))
+    return tmp_path
 
 
 @pytest.mark.parametrize("platform", ["linux-64", "osx-64", "osx-arm64"])
@@ -27,3 +49,42 @@ def test_pr_436(
     (tmp_path / "environment.yml").write_text(spec)
     monkeypatch.chdir(tmp_path)
     run_lock([tmp_path / "environment.yml"], conda_exe=mamba_exe, platforms=[platform])
+
+
+@pytest.mark.parametrize(
+    ["test_dir", "filename"],
+    [
+        (["test-pypi-resolve-gh290", "pyproject"], "pyproject.toml"),
+        (["test-pypi-resolve-gh290", "tzdata"], "environment.yaml"),
+        (["test-pypi-resolve-gh290", "wdl"], "environment.yaml"),
+    ],
+)
+def test_conda_pip_regressions_gh290(
+    tmp_path: Path,
+    mamba_exe: str,
+    monkeypatch: "pytest.MonkeyPatch",
+    test_dir: List[str],
+    filename: str,
+):
+    """Simple test that asserts that these engieonments can be locked"""
+    spec = clone_test_dir(test_dir, tmp_path).joinpath(filename)
+    monkeypatch.chdir(spec.parent)
+    run_lock([spec], conda_exe=mamba_exe)
+
+
+@pytest.fixture
+def pip_environment_regression_gh155(tmp_path: Path):
+    return clone_test_dir("test-pypi-resolve-gh155", tmp_path).joinpath(
+        "environment.yml"
+    )
+
+
+def test_run_lock_regression_gh155(
+    monkeypatch: "pytest.MonkeyPatch",
+    pip_environment_regression_gh155: Path,
+    conda_exe: str,
+):
+    monkeypatch.chdir(pip_environment_regression_gh155.parent)
+    if is_micromamba(conda_exe):
+        monkeypatch.setenv("CONDA_FLAGS", "-v")
+    run_lock([pip_environment_regression_gh155], conda_exe=conda_exe)


### PR DESCRIPTION
As part the work on #439 I introduced a new test file for the regressions in order to keep the tests a little cleaner.

This moves the other explicit regression tests over to the new location