### PR TITLE
Capture failed tests as actual step/job failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
             pytest-xdist
 
       - name: Install dev deps
+        shell: bash -eo pipefail -l {0}
         run: |
           set -x
           echo "${PATH}"
@@ -96,13 +97,13 @@ jobs:
           python -m pip install -r requirements-dev.txt
 
       - name: install conda-lock
-        shell: bash -l {0}
+        shell: bash -eo pipefail -l {0}
         run: |
           which pip
           pip install -e . --force-reinstall
 
       - name: run-test
-        shell: bash -l {0}
+        shell: bash -eo pipefail -l {0}
         run: |
           cp pyproject.toml "${RUNNER_TEMP}/"
           cp -a tests "${RUNNER_TEMP}/"
@@ -116,7 +117,7 @@ jobs:
       - uses: codecov/codecov-action@v3
 
       - name: test-gdal
-        shell: bash -l {0}
+        shell: bash -eo pipefail -l {0}
         run: |
           pushd "${RUNNER_TEMP}/tests/gdal"
           export TMPDIR="${RUNNER_TEMP}"

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -492,14 +492,7 @@ def update_specs_for_arch(
                     f"Could not lock the environment for platform {platform}: {err_json.get('message')}"
                 ) from exc
 
-            conda_update_output = proc.stdout
-
-            # <https://github.com/conda/conda-lock/pull/448#issuecomment-1627530087>
-            conda_update_output = conda_update_output.replace(
-                "No package record found!", ""
-            )
-
-            dryrun_install: DryRunInstall = json.loads(conda_update_output)
+            dryrun_install: DryRunInstall = json.loads(extract_json_object(proc.stdout))
         else:
             dryrun_install = {"actions": {"LINK": [], "FETCH": []}}
 

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -492,7 +492,14 @@ def update_specs_for_arch(
                     f"Could not lock the environment for platform {platform}: {err_json.get('message')}"
                 ) from exc
 
-            dryrun_install: DryRunInstall = json.loads(proc.stdout)
+            conda_update_output = proc.stdout
+
+            # <https://github.com/conda/conda-lock/pull/448#issuecomment-1627530087>
+            conda_update_output = conda_update_output.replace(
+                "No package record found!", ""
+            )
+
+            dryrun_install: DryRunInstall = json.loads(conda_update_output)
         else:
             dryrun_install = {"actions": {"LINK": [], "FETCH": []}}
 


### PR DESCRIPTION
Should fix  #447

This is done by Enabling fail-fast bash behavior, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
