### PR TITLE
Protect against unordered extras in pip dependencies

### DIFF
--- a/conda_lock/models/lock_spec.py
+++ b/conda_lock/models/lock_spec.py
@@ -19,6 +19,10 @@ class _BaseDependency(StrictModel):
     category: str = "main"
     extras: List[str] = []
 
+    @validator("extras")
+    def sorted_extras(cls, v: List[str]) -> List[str]:
+        return sorted(v)
+
 
 class VersionedDependency(_BaseDependency):
     version: str

--- a/tests/test-pypi-resolve-gh449/environment.yml
+++ b/tests/test-pypi-resolve-gh449/environment.yml
@@ -1,0 +1,7 @@
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+    - pydantic[email,dotenv]==1.10.10
+channels:
+  - defaults

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -153,6 +153,13 @@ def pip_environment_different_names_same_deps(tmp_path: Path):
 
 
 @pytest.fixture
+def pip_environment_with_extras(tmp_path: Path):
+    return clone_test_dir("test-pypi-resolve-gh449", tmp_path).joinpath(
+        "environment.yml"
+    )
+
+
+@pytest.fixture
 def pip_local_package_environment(tmp_path: Path):
     return clone_test_dir("test-local-pip", tmp_path).joinpath("environment.yml")
 
@@ -398,6 +405,20 @@ def test_parse_environment_file_with_pip(pip_environment: Path):
                 category="main",
                 extras=[],
                 version="=0.9.1",
+            )
+        ]
+
+
+def test_parse_environment_file_with_pip_extras(pip_environment_with_extras: Path):
+    res = parse_environment_file(pip_environment_with_extras, DEFAULT_PLATFORMS)
+    for plat in DEFAULT_PLATFORMS:
+        assert [dep for dep in res.dependencies[plat] if dep.manager == "pip"] == [
+            VersionedDependency(
+                name="pydantic",
+                manager="pip",
+                category="main",
+                extras=["dotenv", "email"],
+                version="=1.10.10",
             )
         ]
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -153,13 +153,6 @@ def pip_environment_different_names_same_deps(tmp_path: Path):
 
 
 @pytest.fixture
-def pip_environment_with_extras(tmp_path: Path):
-    return clone_test_dir("test-pypi-resolve-gh449", tmp_path).joinpath(
-        "environment.yml"
-    )
-
-
-@pytest.fixture
 def pip_local_package_environment(tmp_path: Path):
     return clone_test_dir("test-local-pip", tmp_path).joinpath("environment.yml")
 
@@ -405,20 +398,6 @@ def test_parse_environment_file_with_pip(pip_environment: Path):
                 category="main",
                 extras=[],
                 version="=0.9.1",
-            )
-        ]
-
-
-def test_parse_environment_file_with_pip_extras(pip_environment_with_extras: Path):
-    res = parse_environment_file(pip_environment_with_extras, DEFAULT_PLATFORMS)
-    for plat in DEFAULT_PLATFORMS:
-        assert [dep for dep in res.dependencies[plat] if dep.manager == "pip"] == [
-            VersionedDependency(
-                name="pydantic",
-                manager="pip",
-                category="main",
-                extras=["dotenv", "email"],
-                version="=1.10.10",
             )
         ]
 


### PR DESCRIPTION


<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

By sorting the extras in VersionedDependency this should help addresses hash instability as mentioned in #449.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
