### PR TITLE
Fix virtual package versions being detected as floats

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,11 +227,11 @@ If you want to override which virtual packages are injected you can create a fil
 subdirs:
   linux-64:
     packages:
-      __glibc: 2.17
-      __cuda: 11.4
+      __glibc: "2.17"
+      __cuda: "11.4"
   win-64:
     packages:
-      __cuda: 11.4
+      __cuda: "11.4"
 ```
 
 conda-lock will automatically use a `virtual-packages.yml` it finds in the the current working directory.  Alternatively one can be specified

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -145,11 +145,11 @@ If you want to override which virtual packages are injected you can create a vir
 subdirs:
   linux-64:
     packages:
-      __glibc: 2.17
-      __cuda: 11.4
+      __glibc: "2.17"
+      __cuda: "11.4"
   win-64:
     packages:
-      __cuda: 11.4
+      __cuda: "11.4"
 ```
 
 conda-lock will automatically use a `virtual-packages.yml` it finds in the the current working directory.  Alternatively one can be specified

--- a/tests/test-cuda/virtual-packages-old-glibc.yaml
+++ b/tests/test-cuda/virtual-packages-old-glibc.yaml
@@ -1,4 +1,4 @@
 subdirs:
   linux-64:
     packages:
-      __glibc: 2.11
+      __glibc: "2.11"

--- a/tests/test-cuda/virtual-packages.yaml
+++ b/tests/test-cuda/virtual-packages.yaml
@@ -1,4 +1,4 @@
 subdirs:
   linux-64:
     packages:
-      __glibc: 2.17
+      __glibc: "2.17"


### PR DESCRIPTION

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Looks like either Pydantic 2 parsing is breaking something or a failing test may have gotten merged.

This fixes it by quoting the `X.Y`-style version strings

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
