### PR TITLE
Include "fn" in fake_conda_environment for mamba>=1.4.6 compatibility

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -561,7 +561,6 @@ def fake_conda_environment(
             channel = urlunsplit(
                 (url.scheme, url.hostname, str(path.parent), None, None)
             )
-            file_name = path.name
             while path.suffix in {".tar", ".bz2", ".gz", ".conda"}:
                 path = path.with_suffix("")
             build = path.name.split("-")[-1]
@@ -578,7 +577,7 @@ def fake_conda_environment(
                 "build_number": build_number,
                 "version": dep.version,
                 "subdir": path.parent.name,
-                "fn": file_name,
+                "fn": path.name,
                 "depends": [f"{k} {v}".strip() for k, v in dep.dependencies.items()],
             }
             # mamba requires these to be stringlike so null are not allowed here

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -492,7 +492,7 @@ def update_specs_for_arch(
                     f"Could not lock the environment for platform {platform}: {err_json.get('message')}"
                 ) from exc
 
-            dryrun_install: DryRunInstall = json.loads(extract_json_object(proc.stdout))
+            dryrun_install: DryRunInstall = json.loads(proc.stdout)
         else:
             dryrun_install = {"actions": {"LINK": [], "FETCH": []}}
 

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -492,7 +492,7 @@ def update_specs_for_arch(
                     f"Could not lock the environment for platform {platform}: {err_json.get('message')}"
                 ) from exc
 
-            dryrun_install: DryRunInstall = json.loads(proc.stdout)
+            dryrun_install: DryRunInstall = json.loads(extract_json_object(proc.stdout))
         else:
             dryrun_install = {"actions": {"LINK": [], "FETCH": []}}
 

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -561,6 +561,7 @@ def fake_conda_environment(
             channel = urlunsplit(
                 (url.scheme, url.hostname, str(path.parent), None, None)
             )
+            file_name = path.name
             while path.suffix in {".tar", ".bz2", ".gz", ".conda"}:
                 path = path.with_suffix("")
             build = path.name.split("-")[-1]
@@ -577,6 +578,7 @@ def fake_conda_environment(
                 "build_number": build_number,
                 "version": dep.version,
                 "subdir": path.parent.name,
+                "fn": file_name,
                 "depends": [f"{k} {v}".strip() for k, v in dep.dependencies.items()],
             }
             # mamba requires these to be stringlike so null are not allowed here


### PR DESCRIPTION
### Description

See #452. The initial goal of this (draft) PR is to provide evidence about the fact that including the file name ("fn") in the fake environment packages' JSON file makes mamba>=1.4.6 happy