### PR TITLE
Remove deprecated pkg_resources and standardize canonicalization

### DIFF
--- a/conda_lock/__init__.py
+++ b/conda_lock/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.metadata import distribution
 
 from conda_lock.conda_lock import main
 
@@ -7,6 +7,6 @@ __all__ = ["main"]
 
 
 try:
-    __version__ = pkg_resources.get_distribution("conda_lock").version
+    __version__ = distribution("conda_lock").version
 except Exception:
     __version__ = "unknown"

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -15,6 +15,7 @@ import tempfile
 
 from contextlib import contextmanager
 from functools import partial
+from importlib.metadata import distribution
 from types import TracebackType
 from typing import (
     AbstractSet,
@@ -32,7 +33,6 @@ from typing import (
 from urllib.parse import urlsplit
 
 import click
-import pkg_resources
 import yaml
 
 from ensureconda.api import ensureconda
@@ -482,7 +482,7 @@ def do_render(
                     "platform": plat,
                     "dev-dependencies": str(include_dev_dependencies).lower(),
                     "input-hash": lockfile.metadata.content_hash,
-                    "version": pkg_resources.get_distribution("conda_lock").version,
+                    "version": distribution("conda_lock").version,
                     "timestamp": datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ"),
                 }
 

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -70,7 +70,7 @@ def apply_categories(
         # If we operate on lists of pip names and this is a conda dependency, we
         # convert the name to a pip name.
         if convert_to_pip_names and manager == "conda":
-            return conda_name_to_pypi_name(dep).lower()
+            return conda_name_to_pypi_name(dep)
         return dep
 
     for name, request in requested.items():

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -346,7 +346,7 @@ def solve_pypi(
     # is essentially a dictionary of:
     #  - pip package name -> list of LockedDependency that are needed for this package
     for conda_name, locked_dep in conda_locked.items():
-        pypi_name = conda_name_to_pypi_name(conda_name).lower()
+        pypi_name = conda_name_to_pypi_name(conda_name)
         if pypi_name in planned:
             planned[pypi_name].append(locked_dep)
         else:

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -74,17 +74,19 @@ def join_version_components(pieces: Sequence[Union[str, int]]) -> str:
 
 
 def normalize_pypi_name(name: str) -> str:
-    name = name.replace("_", "-").lower()
-    if name in get_lookup():
-        lookup = get_lookup()[name]
+    cname = canonicalize_pypi_name(name)
+    if cname in get_lookup():
+        lookup = get_lookup()[cname]
         res = lookup.get("conda_name") or lookup.get("conda_forge")
         if res is not None:
             return res
         else:
-            logging.warning(f"Could not find conda name for {name}. Assuming identity.")
-            return name
+            logging.warning(
+                f"Could not find conda name for {cname}. Assuming identity."
+            )
+            return cname
     else:
-        return name
+        return cname
 
 
 def poetry_version_to_conda_version(version_string: Optional[str]) -> Optional[str]:
@@ -377,6 +379,8 @@ def parse_requirement_specifier(
         # Handle the case where only the URL is specified without a package name
         repo_name_and_maybe_tag = requirement.split("/")[-1]
         repo_name = repo_name_and_maybe_tag.split("@")[0]
+        if repo_name.endswith(".git"):
+            repo_name = repo_name[:-4]
         # Use the repo name as a placeholder for the package name
         return Requirement(f"{repo_name} @ {requirement}")
     else:

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -25,7 +25,8 @@ if sys.version_info >= (3, 11):
 else:
     from tomli import load as toml_load
 
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name as canonicalize_pypi_name
 from typing_extensions import Literal
 
 from conda_lock.common import get_in
@@ -368,19 +369,18 @@ def parse_requirement_specifier(
     requirement: str,
 ) -> Requirement:
     """Parse a url requirement to a conda spec"""
-    requirement_specifier = requirement.split(";")[0].strip()
-
     if (
-        requirement_specifier.startswith("git+")
-        or requirement_specifier.startswith("https://")
-        or requirement_specifier.startswith("ssh://")
+        requirement.startswith("git+")
+        or requirement.startswith("https://")
+        or requirement.startswith("ssh://")
     ):
-        parsed_req = Requirement.parse(
-            requirement_specifier.split("/")[-1].replace("@", "==")
-        )
-        parsed_req.url = requirement_specifier
-        return parsed_req
-    return Requirement.parse(requirement_specifier)
+        # Handle the case where only the URL is specified without a package name
+        repo_name_and_maybe_tag = requirement.split("/")[-1]
+        repo_name = repo_name_and_maybe_tag.split("@")[0]
+        # Use the repo name as a placeholder for the package name
+        return Requirement(f"{repo_name} @ {requirement}")
+    else:
+        return Requirement(requirement)
 
 
 def unpack_git_url(url: str) -> Tuple[str, Optional[str]]:
@@ -407,8 +407,8 @@ def parse_python_requirement(
 ) -> Dependency:
     """Parse a requirements.txt like requirement to a conda spec"""
     parsed_req = parse_requirement_specifier(requirement)
-    name = parsed_req.unsafe_name.lower()
-    collapsed_version = ",".join("".join(spec) for spec in parsed_req.specs)
+    name = canonicalize_pypi_name(parsed_req.name)
+    collapsed_version = str(parsed_req.specifier)
     conda_version = poetry_version_to_conda_version(collapsed_version)
     if conda_version:
         conda_version = ",".join(sorted(conda_version.split(",")))


### PR DESCRIPTION
### Description

I'm trying to move things to more standard tooling. `pkg_resources` was deprecated some time ago. PyPI names should be canonicalized with `packaging.utils.canonicalize_name`.

TODO: Track down why the deprecation warnings for `pkg_resources` are being suppressed.



<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
