### PR TITLE
Consolidate vendored imports into a single module

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -16,7 +16,7 @@ import yaml
 
 from typing_extensions import TypedDict
 
-from conda_lock._vendor.conda.models.match_spec import MatchSpec
+from conda_lock.interfaces.vendored_conda import MatchSpec
 from conda_lock.invoke_conda import (
     PathLike,
     _get_conda_flags,

--- a/conda_lock/interfaces/vendored_conda.py
+++ b/conda_lock/interfaces/vendored_conda.py
@@ -1,0 +1,5 @@
+from conda_lock._vendor.conda.common.toposort import toposort
+from conda_lock._vendor.conda.models.match_spec import MatchSpec
+
+
+__all__ = ["toposort", "MatchSpec"]

--- a/conda_lock/interfaces/vendored_poetry.py
+++ b/conda_lock/interfaces/vendored_poetry.py
@@ -1,0 +1,32 @@
+from conda_lock._vendor.poetry.core.packages import Dependency as PoetryDependency
+from conda_lock._vendor.poetry.core.packages import Package as PoetryPackage
+from conda_lock._vendor.poetry.core.packages import (
+    ProjectPackage as PoetryProjectPackage,
+)
+from conda_lock._vendor.poetry.core.packages import URLDependency as PoetryURLDependency
+from conda_lock._vendor.poetry.core.packages import VCSDependency as PoetryVCSDependency
+from conda_lock._vendor.poetry.factory import Factory
+from conda_lock._vendor.poetry.installation.chooser import Chooser
+from conda_lock._vendor.poetry.installation.operations.uninstall import Uninstall
+from conda_lock._vendor.poetry.puzzle import Solver as PoetrySolver
+from conda_lock._vendor.poetry.repositories.pool import Pool
+from conda_lock._vendor.poetry.repositories.pypi_repository import PyPiRepository
+from conda_lock._vendor.poetry.repositories.repository import Repository
+from conda_lock._vendor.poetry.utils.env import Env
+
+
+__all__ = [
+    "Chooser",
+    "Env",
+    "Factory",
+    "PoetryDependency",
+    "PoetryPackage",
+    "PoetryProjectPackage",
+    "PoetrySolver",
+    "PoetryURLDependency",
+    "PoetryVCSDependency",
+    "Pool",
+    "PyPiRepository",
+    "Repository",
+    "Uninstall",
+]

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -80,7 +80,7 @@ class Lockfile(StrictModel):
         # Resort the conda packages topologically
         final_package: List[LockedDependency] = []
         for platform in sorted(platforms):
-            from conda_lock._vendor.conda.common.toposort import toposort
+            from conda_lock.interfaces.vendored_conda import toposort
 
             # Add the remaining non-conda packages in the order in which they appeared.
             # Order the pip packages topologically ordered (might be not 100% perfect if they depend on

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -9,21 +9,21 @@ from clikit.api.io.flags import VERY_VERBOSE
 from clikit.io import ConsoleIO, NullIO
 from packaging.tags import compatible_tags, cpython_tags, mac_platforms
 
-from conda_lock._vendor.poetry.core.packages import Dependency as PoetryDependency
-from conda_lock._vendor.poetry.core.packages import Package as PoetryPackage
-from conda_lock._vendor.poetry.core.packages import (
-    ProjectPackage as PoetryProjectPackage,
+from conda_lock.interfaces.vendored_poetry import (
+    Chooser,
+    Env,
+    Factory,
+    PoetryDependency,
+    PoetryPackage,
+    PoetryProjectPackage,
+    PoetrySolver,
+    PoetryURLDependency,
+    PoetryVCSDependency,
+    Pool,
+    PyPiRepository,
+    Repository,
+    Uninstall,
 )
-from conda_lock._vendor.poetry.core.packages import URLDependency as PoetryURLDependency
-from conda_lock._vendor.poetry.core.packages import VCSDependency as PoetryVCSDependency
-from conda_lock._vendor.poetry.factory import Factory
-from conda_lock._vendor.poetry.installation.chooser import Chooser
-from conda_lock._vendor.poetry.installation.operations.uninstall import Uninstall
-from conda_lock._vendor.poetry.puzzle import Solver as PoetrySolver
-from conda_lock._vendor.poetry.repositories.pool import Pool
-from conda_lock._vendor.poetry.repositories.pypi_repository import PyPiRepository
-from conda_lock._vendor.poetry.repositories.repository import Repository
-from conda_lock._vendor.poetry.utils.env import Env
 from conda_lock.lockfile import apply_categories
 from conda_lock.lockfile.v2prelim.models import (
     DependencySource,

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type
 
 from pydantic import BaseModel, Field, validator
 
-from conda_lock._vendor.conda.models.match_spec import MatchSpec
+from conda_lock.interfaces.vendored_conda import MatchSpec
 from conda_lock.models.channel import Channel
 
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -28,7 +28,6 @@ from flaky import flaky
 from freezegun import freeze_time
 
 from conda_lock import __version__, pypi_solver
-from conda_lock._vendor.conda.models.match_spec import MatchSpec
 from conda_lock.conda_lock import (
     DEFAULT_FILES,
     DEFAULT_LOCKFILE_NAME,
@@ -51,6 +50,7 @@ from conda_lock.errors import (
     MissingEnvVarError,
     PlatformValidationError,
 )
+from conda_lock.interfaces.vendored_conda import MatchSpec
 from conda_lock.invoke_conda import is_micromamba, reset_conda_pkgs_dir
 from conda_lock.lockfile import parse_conda_lock_file
 from conda_lock.lockfile.v2prelim.models import (


### PR DESCRIPTION
I want it to be clear what we are and aren't using. Ideally we will eventually get rid of vendored dependencies.
