### PR TITLE
Restrict update-lockfile workflow push trigger to main

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -51,6 +51,7 @@ jobs:
         title: Relock dependencies
         body: >
           This pull request relocks the dependencies with conda-lock.
+          It is triggered by [update-lockfile](https://github.com/conda/conda-lock/blob/main/.github/workflows/update-lockfile.yaml).
         branch: relock-deps
         labels: conda-lock
         reviewers: maresb

--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -2,6 +2,8 @@ name: Run conda-lock to update dependencies
 
 on:
   push:
+    branches:
+    - main
   workflow_dispatch:
   schedule:
   # At 5:28am UTC Monday and Thursday


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Running update-lockfile on every push has resulted aggressively opening pull requests on all pushes to branches in my fork.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
