### PR TITLE
Drop implicit `filelock` dependency

### DIFF
--- a/environments/dev-environment.yaml
+++ b/environments/dev-environment.yaml
@@ -7,6 +7,7 @@ dependencies:
 - black
 - check-manifest
 - doctr
+- filelock
 - flake8
 - flake8-builtins
 - flake8-comprehensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dynamic = ["version"]
 license-files = { paths = ["LICENSE"] }
 dependencies = [
+    # conda-lock dependencies
     "click >=8.0",
     "click-default-group",
     "ensureconda >=1.3",
@@ -33,11 +34,11 @@ dependencies = [
     "jinja2",
     "pydantic >=1.8.1",
     "pyyaml >= 5.1",
-    "ruamel.yaml",
     'tomli; python_version<"3.11"',
     "typing-extensions",
+    # conda dependencies
+    "ruamel.yaml",
     "toolz >=0.12.0,<1.0.0",
-    "filelock >=3.8.0",
     # The following dependencies were added in the process of vendoring Poetry 1.1.15.
     # poetry:
     "cachecontrol[filecache] >=0.12.9",


### PR DESCRIPTION

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

It's implied by `cachecontrol[filecache]`.
It is however an explicit dev dependency since it's imported in the test suite.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
