### PR TITLE
Proposed fix for #474: enables parsing of requirements.txt during locking

### DIFF
--- a/conda_lock/src_parser/environment_yaml.py
+++ b/conda_lock/src_parser/environment_yaml.py
@@ -4,11 +4,10 @@ import tempfile
 from typing import List, Tuple
 
 import yaml
-from packaging._parser import parse_requirement
 
 from conda_lock.models.lock_spec import Dependency, LockSpecification
 from conda_lock.src_parser.conda_common import conda_spec_to_versioned_dep
-from conda_lock.src_parser.requirements_txt import parse_requirements_txt
+from conda_lock.src_parser.requirements_txt import parse_requirements_txt, parse_one_requirement
 from conda_lock.src_parser.selectors import filter_platform_selectors
 
 _whitespace = re.compile(r"\s+")
@@ -27,6 +26,7 @@ def _parse_environment_file_for_platform(
     content: str,
     category: str,
     platform: str,
+    source_path: pathlib.Path,
 ) -> List[Dependency]:
     """
     Parse dependencies from a conda environment specification for an
@@ -54,15 +54,17 @@ def _parse_environment_file_for_platform(
     for mapping_spec in mapping_specs:
         if "pip" in mapping_spec:
             # Generate the temporary requirements file
-            with tempfile.NamedTemporaryFile(suffix="requirements.txt", mode='w', encoding='utf-8') as requirements:
+            yaml_dir = source_path.parent
+            with tempfile.NamedTemporaryFile(dir=yaml_dir, suffix="requirements.txt", mode='w', encoding='utf-8') as requirements:
                 requirements.writelines(mapping_spec["pip"])
-                requirements.close()
+                requirements.write("\n")  # Trailing newline
+                requirements.file.close()
 
-                dependencies.extend(filter(None, parse_requirements_txt(requirements.name)))
+                dependencies.extend(parse_requirements_txt(requirements.name, category))
 
             # ensure pip is in target env
             if 'pip' not in {d.name for d in dependencies}:
-                dependencies.append(parse_requirement("pip"))
+                dependencies.append(parse_one_requirement("pip", category))
 
     return dependencies
 
@@ -111,7 +113,7 @@ def parse_environment_file(
 
     # Parse with selectors for each target platform
     dep_map = {
-        platform: _parse_environment_file_for_platform(content, category, platform)
+        platform: _parse_environment_file_for_platform(content, category, platform, environment_file)
         for platform in platforms
     }
 

--- a/conda_lock/src_parser/requirements_txt.py
+++ b/conda_lock/src_parser/requirements_txt.py
@@ -1,0 +1,11 @@
+"""
+Parses pip requirements from a requirements file
+"""
+from pip._internal.network.session import PipSession
+from pip._internal.req.req_file import parse_requirements
+from pip._internal.req.req_file import ParsedRequirement
+
+
+def parse_requirements_txt(file_path):
+    session = PipSession()
+    return parse_requirements(file_path, session)

--- a/conda_lock/src_parser/requirements_txt.py
+++ b/conda_lock/src_parser/requirements_txt.py
@@ -1,11 +1,48 @@
 """
 Parses pip requirements from a requirements file
 """
+from packaging._parser import parse_requirement
 from pip._internal.network.session import PipSession
 from pip._internal.req.req_file import parse_requirements
-from pip._internal.req.req_file import ParsedRequirement
+
+from conda_lock.models.lock_spec import VersionedDependency, VCSDependency, URLDependency, Dependency
+from conda_lock.src_parser.pyproject_toml import unpack_git_url
 
 
-def parse_requirements_txt(file_path):
+def parse_requirements_txt(file_path, category=None) -> Dependency:
     session = PipSession()
-    return parse_requirements(file_path, session)
+    for req in filter(None, parse_requirements(file_path, session)):
+        yield parse_one_requirement(req.requirement, category=category)
+
+
+def parse_one_requirement(req_string: str, category=None) -> Dependency:
+    parsed_req = parse_requirement(req_string)
+
+    if parsed_req.url and parsed_req.url.startswith("git+"):
+        url, rev = unpack_git_url(parsed_req.url)
+        return VCSDependency(
+            name=parsed_req.name,
+            source=url,
+            manager='pip',
+            vcs="git",
+            rev=rev,
+        )
+    elif parsed_req.url:  # type: ignore[attr-defined]
+        assert parsed_req.specifier in {"", "*", None}
+        url, frag = urldefrag(parsed_req.url)  # type: ignore[attr-defined]
+        return URLDependency(
+            name=parsed_req.name,
+            manager='pip',
+            category=category,
+            extras=parsed_req.extras,
+            url=url,
+            hashes=[frag.replace("=", ":")],
+        )
+    else:
+        return VersionedDependency(
+            name=parsed_req.name,
+            version=parsed_req.specifier or "*",
+            manager='pip',
+            category=category,
+            extras=parsed_req.extras,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pyyaml >= 5.1",
     'tomli; python_version<"3.11"',
     "typing-extensions",
+    "pip",
     # conda dependencies
     "ruamel.yaml",
     "toolz >=0.12.0,<1.0.0",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This addresses https://github.com/conda/conda-lock/issues/474, which fails to lock if environment.yml has -rrequirements.txt in the pip requirements. The main problem with the existing implementation is that it treats requirements lists as if they were a tool.poetry.dependencies block in a pyproject.toml. Poetry is great, and I see why you would want to vendor such a clean implementation, but poetry doesn't have any specification for external files. Further, any differences between calling `pip install` and `poetry lock` would eventually cause an issue.

My fix mimics conda's implementation which writes a temporary requirements.txt and invokes the command-line pip install command. https://github.com/conda/conda/blob/main/conda_env/installers/pip.py. Ideally this means there will be fewer bugs/differences between performing `conda env create` and `conda lock`.

Since pip doesn't provide an explicit library or API for parsing I do it by invoking pip's own parse_requirements function. I also based the return values strongly on the pyproject_toml.py implementation. 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

### Testing and Feedback

I would love if somebody could suggest the right place to put unit tests.