### PR TITLE
Remove inapplicable importlib-metadata dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,6 @@ dependencies = [
     "crashtest >=0.3.0",
     # poetry:
     "html5lib >=1.0",
-    # poetry, poetry-core:
-    'importlib-metadata >=1.7.0; python_version <= "3.7"',
     # poetry:
     "keyring >=21.2.0",
     # poetry:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

We pin `python >=3.8` so this is now an empty requirement.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
