### PR TITLE
Don't run scheduled relock on forks

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -8,7 +8,6 @@ on:
   schedule:
   # At 5:28am UTC Monday and Thursday
   - cron: 28 5 * * MON,THU
-  
 
 jobs:
   conda-lock:

--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -8,9 +8,12 @@ on:
   schedule:
   # At 5:28am UTC Monday and Thursday
   - cron: 28 5 * * MON,THU
+  
 
 jobs:
   conda-lock:
+    # Don't run scheduled job on forks. Ref: <https://github.com/orgs/community/discussions/26684#discussioncomment-3252843>
+    if: (github.event_name == 'schedule' && github.repository == 'conda/conda-lock') || (github.event_name != 'schedule')
     defaults:
       run:
         # Ensure the environment is activated


### PR DESCRIPTION


<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This should prevent forks from updating their own dependencies twice a week.
<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
