### PR TITLE
Improve message about selector filtering

### DIFF
--- a/conda_lock/src_parser/selectors.py
+++ b/conda_lock/src_parser/selectors.py
@@ -37,7 +37,8 @@ def filter_platform_selectors(
                 yield line
             else:
                 logger.warning(
-                    "filtered out line `%s` due to unmatchable selector", line
+                    f"filtered out line `{line}` on platform {platform} due to "
+                    f"non-matching selector `{cond}`"
                 )
         else:
             yield line


### PR DESCRIPTION
### Description

The old warnings looked like

```
WARNING:conda_lock.src_parser.selectors:filtered out line `  - gcc_linux-64  # [linux]` due to unmatchable selector
WARNING:conda_lock.src_parser.selectors:filtered out line `  - gcc_linux-aarch64  # [aarch64]` due to unmatchable selector
WARNING:conda_lock.src_parser.selectors:filtered out line `  - gcc_linux-aarch64  # [aarch64]` due to unmatchable selector
```

This doesn't make much sense to me, so I changed them to

```
WARNING:conda_lock.src_parser.selectors:filtered out line `  - gcc_linux-64  # [linux]` on platform osx-arm64 due to non-matching selector `linux`
WARNING:conda_lock.src_parser.selectors:filtered out line `  - gcc_linux-aarch64  # [aarch64]` on platform osx-arm64 due to non-matching selector `aarch64`
WARNING:conda_lock.src_parser.selectors:filtered out line `  - gcc_linux-aarch64  # [aarch64]` on platform linux-64 due to non-matching selector `aarch64`
```

which I understand.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
