### PR TITLE
Detect lockfile type based on contents rather than filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,7 @@ and update operations. You can supply a different filename with e.g.
 conda-lock --lockfile superspecial.conda-lock.yml
 ```
 
-The extension `.conda-lock.yml` will be added if not present. Rendered
-environment files (env or explicit) must end with `.lock` and will be named as
-`"conda-{platform}.lock"` by default.
+Rendered `explicit` and `env` lockfiles will be named as `"conda-{platform}.lock"` and `"conda-{platform}.lock.yml` respectively by default.
 
 If you want to override that call conda-lock as follows.
 ```bash
@@ -89,7 +87,7 @@ conda-lock -k explicit --filename-template "specific-{platform}.conda.lock"
 Conda-lock will build a spec list from several files if requested.
 
 ```bash
-conda-lock -f base.yml -f specific.yml -p linux-64 --filename-template "specific-{platform}.lock"
+conda-lock -f base.yml -f specific.yml -p linux-64 -k explicit --filename-template "specific-{platform}.lock"
 ````
 
 In this case all dependencies are combined, and the ordered union of all `channels` is used as the final

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -36,6 +36,7 @@ import click
 import yaml
 
 from ensureconda.api import ensureconda
+from ensureconda.resolve import platform_subdir
 from typing_extensions import Literal
 
 from conda_lock.click_helpers import OrderedGroup
@@ -946,8 +947,6 @@ def _render_lockfile_for_install(
         return
 
     lock_content = parse_conda_lock_file(pathlib.Path(filename))
-
-    from ensureconda.resolve import platform_subdir
 
     platform = platform_subdir()
     if platform not in lock_content.metadata.platforms:

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -17,6 +17,10 @@ from conda_lock.lookup import conda_name_to_pypi_name
 from conda_lock.models.lock_spec import Dependency
 
 
+class UnknownLockfileVersion(ValueError):
+    pass
+
+
 def _seperator_munge_get(
     d: Mapping[str, Union[List[LockedDependency], LockedDependency]], key: str
 ) -> Union[List[LockedDependency], LockedDependency]:
@@ -136,7 +140,7 @@ def parse_conda_lock_file(path: pathlib.Path) -> Lockfile:
     if version == 1:
         return lockfile_v1_to_v2(LockfileV1.parse_obj(content))
     else:
-        raise ValueError(f"{path} has unknown version {version}")
+        raise UnknownLockfileVersion(f"{path} has unknown version {version}")
 
 
 def write_conda_lock_file(

--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -17,6 +17,10 @@ from conda_lock.lookup import conda_name_to_pypi_name
 from conda_lock.models.lock_spec import Dependency
 
 
+class MissingLockfileVersion(ValueError):
+    pass
+
+
 class UnknownLockfileVersion(ValueError):
     pass
 
@@ -139,6 +143,8 @@ def parse_conda_lock_file(path: pathlib.Path) -> Lockfile:
     version = content.pop("version", None)
     if version == 1:
         return lockfile_v1_to_v2(LockfileV1.parse_obj(content))
+    elif version is None:
+        raise MissingLockfileVersion(f"{path} is missing a version")
     else:
         raise UnknownLockfileVersion(f"{path} has unknown version {version}")
 


### PR DESCRIPTION
### Description

This PR aims to solve https://github.com/conda/conda-lock/issues/464, allowing v2 lockfiles to have arbitrary names. Previously the lockfile renderer would negotiate between `kind=lock` and `kind=explicit` lockfiles based on the `conda-lock.yml` filename suffix.

After this change, the YAML parser is used to distinguish between them. If the lock-file is parse-able YAML, its assumed to be `kind=lock`.

### Notes on documentation

I think some documentation updates are appropriate, most likely under [File naming](https://github.com/conda/conda-lock/blob/main/README.md#file-naming), however I'm a bit confused by how this is currently documented:

> The extension `.conda-lock.yml` will be added if not present.

I don't think this is currently accurate, and can probably just be removed as part of this change?

> Rendered environment files (env or explicit) must end with `.lock` and will be named as
`"conda-{platform}.lock"` by default.

I don't this is correct for `env`, and I'm not sure its actually validated for `explicit` either.



Resolves: https://github.com/conda/conda-lock/issues/464