### PR TITLE
Parses `python` version for `poetry`'s `pyproject.toml`, always managed by `conda`

### DIFF
--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -227,6 +227,11 @@ def parse_poetry_pyproject_toml(
             extras: List[Any] = []
             in_extra: bool = False
 
+            # Poetry spec includes Python version in "tool.poetry.dependencies"
+            # Cannot be managed by pip
+            if depname == "python":
+                manager = "conda"
+
             # Extras can only be defined in `tool.poetry.dependencies`
             if default_category == "main":
                 in_extra = category != "main"

--- a/tests/test-poetry-default-pip/pyproject.toml
+++ b/tests/test-poetry-default-pip/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["conda-lock"]
 
 [tool.poetry.dependencies]
+python = "^3.7"
 requests = "^2.13.0"
 toml = ">=0.10"
 tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }

--- a/tests/test-poetry-git/pyproject.toml
+++ b/tests/test-poetry-git/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["conda-lock"]
 
 [tool.poetry.dependencies]
+python = "^3.7"
 requests = "^2.13.0"
 toml = ">=0.10"
 tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }

--- a/tests/test-poetry-no-pypi/other_project1/pyproject.toml
+++ b/tests/test-poetry-no-pypi/other_project1/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["conda-lock"]
 
 [tool.poetry.dependencies]
+python = "^3.7"
 requests = "^2.13.0"
 toml = ">=0.10"
 tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }

--- a/tests/test-poetry-no-pypi/other_project2/pyproject.toml
+++ b/tests/test-poetry-no-pypi/other_project2/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["conda-lock"]
 
 [tool.poetry.dependencies]
+python = "^3.7"
 requests = "^2.13.0"
 toml = ">=0.10"
 tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }

--- a/tests/test-poetry-no-pypi/pyproject.toml
+++ b/tests/test-poetry-no-pypi/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["conda-lock"]
 
 [tool.poetry.dependencies]
+python = "^3.7"
 requests = "^2.13.0"
 toml = ">=0.10"
 tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }

--- a/tests/test-poetry-optional/pyproject.toml
+++ b/tests/test-poetry-optional/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["conda-lock"]
 
 [tool.poetry.dependencies]
+python = "^3.7"
 toml = ""
 # Checking `optional = true` but not in extra
 tomlkit = { version = "", optional = true }

--- a/tests/test-poetry/pyproject.toml
+++ b/tests/test-poetry/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["conda-lock"]
 
 [tool.poetry.dependencies]
+python = "^3.7"
 requests = "^2.13.0"
 toml = ">=0.10"
 tomlkit = { version = ">=0.7.0,<1.0.0", optional = true }

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -658,6 +658,8 @@ def test_parse_poetry(poetry_pyproject_toml: Path):
         for dep in res.dependencies["linux-64"]
     }
 
+    assert specs["python"].manager == "conda"
+    assert specs["python"].version == ">=3.7,<4.0"
     assert specs["requests"].version == ">=2.13.0,<3.0.0"
     assert specs["toml"].version == ">=0.10"
     assert specs["sqlite"].version == "<3.34"
@@ -678,6 +680,8 @@ def test_parse_poetry_default_pip(poetry_pyproject_toml_default_pip: Path):
         for dep in res.dependencies["linux-64"]
     }
 
+    assert specs["python"].manager == "conda"
+    assert specs["python"].version == ">=3.7,<4.0"
     assert specs["sqlite"].manager == "conda"
     assert specs["certifi"].manager == "conda"
     assert specs["requests"].manager == "pip"


### PR DESCRIPTION
This resolves the oversight uncovered at the tail end of [Default PyPI dependencies for pyproject.toml #334](https://github.com/conda/conda-lock/pull/362).
`Poetry`'s `pyproject.toml` python version is now parsed and always managed by `conda` (as it is not a dependency that can be managed by `pip`)

Added [ Poetry's required Python version](https://python-poetry.org/docs/pyproject/) (search `declaring the python version`) specification for all `poetry` `pyproject.toml` tests

TODO: implement for non-poetry `pyproject.toml` flavors (pdm, filt) - a bit complicated as they have differing implementations / locations for python version specification. 