### PR TITLE
Fix platform validation for non-default names

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1475,7 +1475,7 @@ def install(
     install_func = partial(
         do_conda_install, conda=_conda_exe, prefix=prefix, name=name, copy=copy
     )
-    if validate_platform and not lock_file.name.endswith(DEFAULT_LOCKFILE_NAME):
+    if validate_platform and _detect_lockfile_kind(lock_file) != "lock":
         lockfile_contents = read_file(lock_file)
         try:
             do_validate_platform(lockfile_contents)


### PR DESCRIPTION
### Description

https://github.com/conda/conda-lock/pull/499 added logic to support lockfiles with arbitrary names, by detecting the lockfile kind based on contents rather than name.

However it missed some logic for deciding whether to validate the platform, which still infers lock-file kind from the filename.

This leads to the following error when installing from a lock-file with non-default name:

```
RuntimeError: Cannot find platform in lockfile.
```

This can be worked around by passing `--no-validate-platform`, but is not the intended behaviour.