### PR TITLE
Support pypi repository on the local disk (`file://` urls)

### DIFF
--- a/conda_lock/_vendor/requests_file.LICENSE
+++ b/conda_lock/_vendor/requests_file.LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/conda_lock/_vendor/requests_file.py
+++ b/conda_lock/_vendor/requests_file.py
@@ -82,6 +82,8 @@ class FileAdapter(BaseAdapter):
             if path_drive and not os.path.splitdrive(path):
                 path = os.sep + os.path.join(path_drive, *path_parts)
 
+            if os.path.isdir(path):
+                path = os.path.join(path, "index.html")
             # Use io.open since we need to add a release_conn method, and
             # methods can't be added to file objects in python 2.
             resp.raw = io.open(path, "rb")

--- a/conda_lock/_vendor/requests_file.py
+++ b/conda_lock/_vendor/requests_file.py
@@ -1,0 +1,119 @@
+from requests.adapters import BaseAdapter
+from requests.compat import urlparse, unquote
+from requests import Response, codes
+import errno
+import os
+import stat
+import locale
+import io
+try:
+    from io import BytesIO
+except ImportError:
+    from StringIO import StringIO as BytesIO
+
+
+class FileAdapter(BaseAdapter):
+    def __init__(self, set_content_length=True):
+        super(FileAdapter, self).__init__()
+        self._set_content_length = set_content_length
+
+    def send(self, request, **kwargs):
+        """Wraps a file, described in request, in a Response object.
+
+        :param request: The PreparedRequest` being "sent".
+        :returns: a Response object containing the file
+        """
+
+        # Check that the method makes sense. Only support GET
+        if request.method not in ("GET", "HEAD"):
+            raise ValueError("Invalid request method %s" % request.method)
+
+        # Parse the URL
+        url_parts = urlparse(request.url)
+
+        # Reject URLs with a hostname component
+        if url_parts.netloc and url_parts.netloc != "localhost":
+            raise ValueError("file: URLs with hostname components are not permitted")
+
+        resp = Response()
+
+        # Open the file, translate certain errors into HTTP responses
+        # Use urllib's unquote to translate percent escapes into whatever
+        # they actually need to be
+        try:
+            # Split the path on / (the URL directory separator) and decode any
+            # % escapes in the parts
+            path_parts = [unquote(p) for p in url_parts.path.split("/")]
+
+            # Strip out the leading empty parts created from the leading /'s
+            while path_parts and not path_parts[0]:
+                path_parts.pop(0)
+
+            # If os.sep is in any of the parts, someone fed us some shenanigans.
+            # Treat is like a missing file.
+            if any(os.sep in p for p in path_parts):
+                raise IOError(errno.ENOENT, os.strerror(errno.ENOENT))
+
+            # Look for a drive component. If one is present, store it separately
+            # so that a directory separator can correctly be added to the real
+            # path, and remove any empty path parts between the drive and the path.
+            # Assume that a part ending with : or | (legacy) is a drive.
+            if path_parts and (
+                path_parts[0].endswith("|") or path_parts[0].endswith(":")
+            ):
+                path_drive = path_parts.pop(0)
+                if path_drive.endswith("|"):
+                    path_drive = path_drive[:-1] + ":"
+
+                while path_parts and not path_parts[0]:
+                    path_parts.pop(0)
+            else:
+                path_drive = ""
+
+            # Try to put the path back together
+            # Join the drive back in, and stick os.sep in front of the path to
+            # make it absolute.
+            path = path_drive + os.sep + os.path.join(*path_parts)
+
+            # Check if the drive assumptions above were correct. If path_drive
+            # is set, and os.path.splitdrive does not return a drive, it wasn't
+            # really a drive. Put the path together again treating path_drive
+            # as a normal path component.
+            if path_drive and not os.path.splitdrive(path):
+                path = os.sep + os.path.join(path_drive, *path_parts)
+
+            # Use io.open since we need to add a release_conn method, and
+            # methods can't be added to file objects in python 2.
+            resp.raw = io.open(path, "rb")
+            resp.raw.release_conn = resp.raw.close
+        except IOError as e:
+            if e.errno == errno.EACCES:
+                resp.status_code = codes.forbidden
+            elif e.errno == errno.ENOENT:
+                resp.status_code = codes.not_found
+            else:
+                resp.status_code = codes.bad_request
+
+            # Wrap the error message in a file-like object
+            # The error message will be localized, try to convert the string
+            # representation of the exception into a byte stream
+            resp_str = str(e).encode(locale.getpreferredencoding(False))
+            resp.raw = BytesIO(resp_str)
+            if self._set_content_length:
+                resp.headers["Content-Length"] = len(resp_str)
+
+            # Add release_conn to the BytesIO object
+            resp.raw.release_conn = resp.raw.close
+        else:
+            resp.status_code = codes.ok
+            resp.url = request.url
+
+            # If it's a regular file, set the Content-Length
+            resp_stat = os.fstat(resp.raw.fileno())
+            if stat.S_ISREG(resp_stat.st_mode) and self._set_content_length:
+                resp.headers["Content-Length"] = resp_stat.st_size
+
+        return resp
+
+    def close(self):
+        pass

--- a/conda_lock/interfaces/vendored_poetry.py
+++ b/conda_lock/interfaces/vendored_poetry.py
@@ -1,3 +1,4 @@
+from conda_lock._vendor.poetry.config.config import Config
 from conda_lock._vendor.poetry.core.packages import Dependency as PoetryDependency
 from conda_lock._vendor.poetry.core.packages import Package as PoetryPackage
 from conda_lock._vendor.poetry.core.packages import (
@@ -9,16 +10,22 @@ from conda_lock._vendor.poetry.factory import Factory
 from conda_lock._vendor.poetry.installation.chooser import Chooser
 from conda_lock._vendor.poetry.installation.operations.uninstall import Uninstall
 from conda_lock._vendor.poetry.puzzle import Solver as PoetrySolver
+from conda_lock._vendor.poetry.repositories.legacy_repository import LegacyRepository
 from conda_lock._vendor.poetry.repositories.pool import Pool
 from conda_lock._vendor.poetry.repositories.pypi_repository import PyPiRepository
 from conda_lock._vendor.poetry.repositories.repository import Repository
 from conda_lock._vendor.poetry.utils.env import Env
+from conda_lock._vendor.poetry.utils.helpers import get_cert, get_client_cert
 
 
 __all__ = [
+    "get_cert",
+    "get_client_cert",
     "Chooser",
+    "Config",
     "Env",
     "Factory",
+    "LegacyRepository",
     "PoetryDependency",
     "PoetryPackage",
     "PoetryProjectPackage",

--- a/conda_lock/interfaces/vendored_requests_file.py
+++ b/conda_lock/interfaces/vendored_requests_file.py
@@ -1,0 +1,6 @@
+from conda_lock._vendor.requests_file import FileAdapter
+
+
+__all__ = [
+    "FileAdapter",
+]

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -4,7 +4,9 @@ import sys
 from pathlib import Path
 from posixpath import expandvars
 from typing import TYPE_CHECKING, Dict, List, Optional
-from urllib.parse import urldefrag, urlparse, urlsplit, urlunsplit
+from urllib.parse import urldefrag, urlsplit, urlunsplit
+
+import requests
 
 from clikit.api.io.flags import VERY_VERBOSE
 from clikit.io import ConsoleIO, NullIO
@@ -12,8 +14,10 @@ from packaging.tags import compatible_tags, cpython_tags, mac_platforms
 
 from conda_lock.interfaces.vendored_poetry import (
     Chooser,
+    Config,
     Env,
     Factory,
+    LegacyRepository,
     PoetryDependency,
     PoetryPackage,
     PoetryProjectPackage,
@@ -24,7 +28,10 @@ from conda_lock.interfaces.vendored_poetry import (
     PyPiRepository,
     Repository,
     Uninstall,
+    get_cert,
+    get_client_cert,
 )
+from conda_lock.interfaces.vendored_requests_file import FileAdapter
 from conda_lock.lockfile import apply_categories
 from conda_lock.lockfile.v2prelim.models import (
     DependencySource,
@@ -384,6 +391,28 @@ def solve_pypi(
     return {dep.name: dep for dep in requirements}
 
 
+class CondaLockLegacyRepository(LegacyRepository):
+    @property
+    def session(self) -> requests.Session:
+        _session = super().session
+        _session.mount("file://", FileAdapter())
+        return _session
+
+
+def create_legacy_repository(
+    source: Dict[str, str], auth_config: Config
+) -> LegacyRepository:
+    name = source["name"]
+    url = source["url"]
+    return CondaLockLegacyRepository(
+        name,
+        url,
+        config=auth_config,
+        cert=get_cert(auth_config, name),
+        client_cert=get_client_cert(auth_config, name),
+    )
+
+
 def _prepare_repositories_pool(
     allow_pypi_requests: bool, pip_repositories: Optional[List[PipRepository]] = None
 ) -> Pool:
@@ -397,13 +426,13 @@ def _prepare_repositories_pool(
     """
     factory = Factory()
     config = factory.create_config()
-    repos = [
-        factory.create_legacy_repository(
-            {"name": pip_repository.name, "url": expandvars(pip_repository.url)},
-            config,
-        )
-        for pip_repository in pip_repositories or []
-    ] + [
+
+    legacy_repos = []
+    for pip_repository in pip_repositories or []:
+        repo_cfg = {"name": pip_repository.name, "url": expandvars(pip_repository.url)}
+        legacy_repo = create_legacy_repository(repo_cfg, config)
+        legacy_repos.append(legacy_repo)
+    repos = legacy_repos + [
         factory.create_legacy_repository(
             {"name": source[0], "url": source[1]["url"]}, config
         )


### PR DESCRIPTION
This is a quick PR to support `file://` urls which resolves #536 . 

Since #529 there is support for additional pip repositories. With this PR also local repositories are supported, specified by a `file://` url like this:

```
channels:
  - conda-forge
pip-repositories:
  - file:///some/path/to/local/repo/
dependencies:
  - python=3.11
  - requests=2.26
  - pip:
    - fake-private-package==1.0.0
```

### Why is this needed?

We require some private wheels for our repo but there is no private registry in place. The easiest thing for us seems to be to put the wheels in git lfs which available for every developer. That way we do not need to operate a private pypi service and we circumvent all the hooks with regards to authentication/user accounts.

Running `conda-lock` with a `file://` url triggers an exception by requests:
`requests.exceptions.InvalidSchema: No connection adapters were found for 'file:///some/path/to//'`.

As a follow-up I will submit a patch to the requests-file project but only conda-lock actually needs it.