### PR TITLE
Make recent manylinux wheels findable by pypi_resolver

### DIFF
--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -40,8 +40,10 @@ if TYPE_CHECKING:
     from packaging.tags import Tag
 
 
-# NB: in principle these depend on the glibc in the conda env
-MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17"]
+# NB: in principle these depend on the glibc on the machine creating the conda env.
+# We use tags supported by manylinux Docker images, which are likely the most common
+# in practice, see https://github.com/pypa/manylinux/blob/main/README.rst#docker-images.
+MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17", "_2_24", "_2_28"]
 # This needs to be updated periodically as new macOS versions are released.
 MACOS_VERSION = (13, 4)
 


### PR DESCRIPTION
### Description

Fix #517. For now I have added 2 manylinux tags, for which manylinux provides a Docker image. I am guessing they are the most used manylinux wheels for recent wheels (i.e. more recent than manylinux2014, which is the same as manylinux_2_17).

Having said that other wheels likely exist in the wild, e.g. https://github.com/conda/conda-lock/issues/395 is a 2_27 wheel. An alternative would be to list all the possible versions between `2_17` and `2_28` (the latest Docker image).

Note this could pose an issue if the glibc on the machine you are doing `conda lock install` does not have a recent enough glibc. As a data point, Ubuntu 18.04 (not supported any more) has glibc 2.27, Ubuntu 20.04 has glibc 2.31.

I have added a test as well using lightgbm and making sure that the resolved url points to a wheel that is more recent than (2, 17).