### PR TITLE
feat: add pypi-to-conda-name overrides to pyproject parsing

### DIFF
--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -30,7 +30,10 @@ from packaging.utils import canonicalize_name as canonicalize_pypi_name
 from typing_extensions import Literal
 
 from conda_lock.common import get_in
-from conda_lock.lookup import get_forward_lookup as get_lookup
+from conda_lock.lookup import (
+    get_forward_lookup as get_lookup,
+    set_pypi_lookup_overrides,
+)
 from conda_lock.models.lock_spec import (
     Dependency,
     LockSpecification,
@@ -558,6 +561,10 @@ def parse_pyproject_toml(
     with pyproject_toml.open("rb") as fp:
         contents = toml_load(fp)
     build_system = get_in(["build-system", "build-backend"], contents)
+
+    pypi_map = get_in(["tool", "conda-lock", "pypi-to-conda-name"], contents, False)
+    if pypi_map:
+        set_pypi_lookup_overrides(pypi_map)
 
     if get_in(
         ["tool", "conda-lock", "skip-non-conda-lock"],

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -32,6 +32,8 @@ from typing_extensions import Literal
 from conda_lock.common import get_in
 from conda_lock.lookup import (
     get_forward_lookup as get_lookup,
+)
+from conda_lock.lookup import (
     set_pypi_lookup_overrides,
 )
 from conda_lock.models.lock_spec import (


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes #548  by adding support for a `pypi-to-conda-name`  section in pyproject.toml

```toml
[tool.conda-lock.pypi-to-conda-name]
cupy-cuda11x = "cupy"
```

names present there will override mappings provided by grayskull

Note: in #548, I proposed accepting a string or list of strings (which I do think is a good idea), but the implications of accepting a list of strings breaks the current 1-to-1 mapping behavior between pypi and conda, so I think that's probably best handled in a followup PR.  This PR only accepts single string
