### PR TITLE
Don't filter in toposort

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -609,6 +609,7 @@ def render_lockfile_for_platform(  # noqa: C901
 
     # ensure consistent ordering of generated file
     lockfile.toposort_inplace()
+    lockfile.filter_virtual_packages_inplace()
 
     for p in lockfile.package:
         if p.platform == platform and p.category in categories:

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -414,7 +414,7 @@ def make_lock_files(  # noqa: C901
                     deep=True,
                     update={"package": packages_not_to_lock},
                 )
-                new_lock_content = lock_content_to_persist | fresh_lock_content
+                new_lock_content = lock_content_to_persist.merge(fresh_lock_content)
 
             if "lock" in kinds:
                 write_conda_lock_file(

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -39,10 +39,7 @@ class Lockfile(StrictModel):
     package: List[LockedDependency]
     metadata: LockMeta
 
-    def __or__(self, other: "Lockfile") -> "Lockfile":
-        return other.__ror__(self)
-
-    def __ror__(self, other: "Optional[Lockfile]") -> "Lockfile":
+    def merge(self, other: "Optional[Lockfile]") -> "Lockfile":
         """
         merge self into other
         """

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -118,10 +118,6 @@ class Lockfile(StrictModel):
                         continue
                     if dep.manager != manager:
                         continue
-                    # skip virtual packages
-                    if dep.manager == "conda" and dep.name.startswith("__"):
-                        continue
-
                     final_package.append(dep)
 
         return final_package

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -84,9 +84,7 @@ class Lockfile(StrictModel):
         ]
 
     @staticmethod
-    def _toposort(
-        package: List[LockedDependency], update: bool = False
-    ) -> List[LockedDependency]:
+    def _toposort(package: List[LockedDependency]) -> List[LockedDependency]:
         platforms = {d.platform for d in package}
 
         # Resort the conda packages topologically


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Before this PR, toposort would drop items (the virtual packages). I wouldn't expect a sort operation to do this. This is a major bug hazard, see #556 and also potentially #557. I've spit this out filtering into a separate step.

Other commits implement some minor cleanups along the way.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
