### PR TITLE
Make the Python resolver respect any __glibc constraint

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -762,6 +762,11 @@ def _solve_for_arch(
             conda_locked={dep.name: dep for dep in conda_deps.values()},
             python_version=conda_deps["python"].version,
             platform=platform,
+            platform_virtual_packages=spec.virtual_package_repo.all_repodata.get(
+                platform, {"packages": None}
+            )["packages"]
+            if spec.virtual_package_repo
+            else None,
             pip_repositories=pip_repositories,
             allow_pypi_requests=spec.allow_pypi_requests,
             strip_auth=strip_auth,

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -77,11 +77,11 @@ class PlatformEnv(Env):
                 for p in platform_virtual_packages.values():
                     if p["name"] == "__glibc":
                         glibc_version = p["version"]
-                glibc_version_splits = glibc_version.split(".")
+                glibc_version_splits = list(map(int, glibc_version.split(".")))
                 for tag in MANYLINUX_TAGS:
                     if tag[0] == "_":
                         # Compare to see if glibc_version is greater than this version
-                        if tag[1:].split("_") > glibc_version_splits:
+                        if list(map(int, tag[1:].split("_"))) > glibc_version_splits:
                             break
                     self._platforms.append(f"manylinux{tag}_{arch}")
                     if tag == glibc_version:  # Catches 1 and 2010 case

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -71,7 +71,8 @@ class PlatformEnv(Env):
             # as provided by __glibc if present
             self._platforms = []
             if platform_virtual_packages:
-                # By default, look for all tags in MANYLINUX_TAGS
+                # Get the glibc_version from virtual packages, falling back to
+                # the last of MANYLINUX_TAGS when absent
                 glibc_version = MANYLINUX_TAGS[-1]
                 for p in platform_virtual_packages.values():
                     if p["name"] == "__glibc":

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -1,14 +1,16 @@
 import re
 import sys
+import warnings
 
 from pathlib import Path
 from posixpath import expandvars
-from typing import TYPE_CHECKING, Dict, List, Optional
-from urllib.parse import urldefrag, urlparse, urlsplit, urlunsplit
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple
+from urllib.parse import urldefrag, urlsplit, urlunsplit
 
 from clikit.api.io.flags import VERY_VERBOSE
 from clikit.io import ConsoleIO, NullIO
 from packaging.tags import compatible_tags, cpython_tags, mac_platforms
+from packaging.version import Version
 
 from conda_lock.interfaces.vendored_poetry import (
     Chooser,
@@ -39,7 +41,6 @@ from conda_lock.models.pip_repository import PipRepository
 if TYPE_CHECKING:
     from packaging.tags import Tag
 
-
 # NB: in principle these depend on the glibc on the machine creating the conda env.
 # We use tags supported by manylinux Docker images, which are likely the most common
 # in practice, see https://github.com/pypa/manylinux/blob/main/README.rst#docker-images.
@@ -55,6 +56,12 @@ class PlatformEnv(Env):
     Fake poetry Env to match PyPI distributions to the target conda environment
     """
 
+    _sys_platform: Literal["darwin", "linux", "win32"]
+    _platform_system: Literal["Darwin", "Linux", "Windows"]
+    _os_name: Literal["posix", "nt"]
+    _platforms: List[str]
+    _python_version: Tuple[int, ...]
+
     def __init__(
         self,
         python_version: str,
@@ -67,33 +74,12 @@ class PlatformEnv(Env):
             arch = "x86_64"
 
         if system == "linux":
-            # We use MANYLINUX_TAGS but only go up to the latest supported version
-            # as provided by __glibc if present
-            self._platforms = []
-            if platform_virtual_packages:
-                # Get the glibc_version from virtual packages, falling back to
-                # the last of MANYLINUX_TAGS when absent
-                glibc_version = MANYLINUX_TAGS[-1]
-                for p in platform_virtual_packages.values():
-                    if p["name"] == "__glibc":
-                        glibc_version = p["version"]
-                glibc_version_splits = list(map(int, glibc_version.split(".")))
-                for tag in MANYLINUX_TAGS:
-                    if tag[0] == "_":
-                        # Compare to see if glibc_version is greater than this version
-                        if list(map(int, tag[1:].split("_"))) > glibc_version_splits:
-                            break
-                    self._platforms.append(f"manylinux{tag}_{arch}")
-                    if tag == glibc_version:  # Catches 1 and 2010 case
-                        # We go no further than the maximum specific GLIBC version
-                        break
-                # Latest tag is most preferred so list first
-                self._platforms.reverse()
-            else:
-                self._platforms = [
-                    f"manylinux{tag}_{arch}" for tag in reversed(MANYLINUX_TAGS)
-                ]
-            self._platforms.append(f"linux_{arch}")
+            compatible_manylinux_tags = _compute_compatible_manylinux_tags(
+                platform_virtual_packages=platform_virtual_packages
+            )
+            self._platforms = [
+                f"manylinux{tag}_{arch}" for tag in compatible_manylinux_tags
+            ] + [f"linux_{arch}"]
         elif system == "osx":
             self._platforms = list(mac_platforms(MACOS_VERSION, arch))
         elif platform == "win-64":
@@ -138,6 +124,115 @@ class PlatformEnv(Env):
             "platform_system": self._platform_system,
             "os_name": self._os_name,
         }
+
+
+def _extract_glibc_version_from_virtual_packages(
+    platform_virtual_packages: Dict[str, dict]
+) -> Optional[Version]:
+    """Get the glibc version from the "package" repodata of a chosen platform.
+
+    Note that the glibc version coming from a virtual package is never a legacy
+    manylinux tag (i.e. 1, 2010, or 2014). Those tags predate PEP 600 which
+    introduced manylinux tags containing the glibc version. Currently, all
+    relevant glibc versions look like 2.XX.
+
+    >>> platform_virtual_packages = {
+    ...     "__glibc-2.17-0.tar.bz2": {
+    ...         "name": "__glibc",
+    ...         "version": "2.17",
+    ...     },
+    ... }
+    >>> _extract_glibc_version_from_virtual_packages(platform_virtual_packages)
+    <Version('2.17')>
+    >>> _extract_glibc_version_from_virtual_packages({}) is None
+    True
+    """
+    matches: List[Version] = []
+    for p in platform_virtual_packages.values():
+        if p["name"] == "__glibc":
+            matches.append(Version(p["version"]))
+    if len(matches) == 0:
+        return None
+    elif len(matches) == 1:
+        return matches[0]
+    else:
+        lowest = min(matches)
+        warnings.warn(
+            f"Multiple __glibc virtual package entries found! "
+            f"{matches=} Using the lowest version {lowest}."
+        )
+        return lowest
+
+
+def _glibc_version_from_manylinux_tag(tag: str) -> Version:
+    """
+    Return the glibc version for the given manylinux tag
+
+    >>> _glibc_version_from_manylinux_tag("2010")
+    <Version('2.12')>
+    >>> _glibc_version_from_manylinux_tag("_2_28")
+    <Version('2.28')>
+    """
+    SPECIAL_CASES = {
+        "1": Version("2.5"),
+        "2010": Version("2.12"),
+        "2014": Version("2.17"),
+    }
+    if tag in SPECIAL_CASES:
+        return SPECIAL_CASES[tag]
+    elif tag.startswith("_"):
+        return Version(tag[1:].replace("_", "."))
+    else:
+        raise ValueError(f"Unknown manylinux tag {tag}")
+
+
+def _compute_compatible_manylinux_tags(
+    platform_virtual_packages: Optional[Dict[str, dict]]
+) -> List[str]:
+    """Determine the manylinux tags that are compatible with the given platform.
+
+    If there is no glibc virtual package, then assume that all manylinux tags are
+    compatible.
+
+    The result is sorted in descending order in order to favor the latest.
+
+    >>> platform_virtual_packages = {
+    ...     "__glibc-2.24-0.tar.bz2": {
+    ...         "name": "__glibc",
+    ...         "version": "2.24",
+    ...     },
+    ... }
+    >>> _compute_compatible_manylinux_tags({}) == list(reversed(MANYLINUX_TAGS))
+    True
+    >>> _compute_compatible_manylinux_tags(platform_virtual_packages)
+    ['_2_24', '_2_17', '2014', '2010', '1']
+    """
+    # We use MANYLINUX_TAGS but only go up to the latest supported version
+    # as provided by __glibc if present
+
+    latest_supported_glibc_version: Optional[Version] = None
+    # Try to get the glibc version from the virtual packages if it exists
+    if platform_virtual_packages:
+        latest_supported_glibc_version = _extract_glibc_version_from_virtual_packages(
+            platform_virtual_packages
+        )
+    # Fall back to the latest of MANYLINUX_TAGS
+    if latest_supported_glibc_version is None:
+        latest_supported_glibc_version = _glibc_version_from_manylinux_tag(
+            MANYLINUX_TAGS[-1]
+        )
+
+    # The glibc versions are backwards compatible, so filter the MANYLINUX_TAGS
+    # to those compatible with less than or equal to the latest supported
+    # glibc version.
+    # Note that MANYLINUX_TAGS is sorted in ascending order. The latest tag
+    # is most preferred so we reverse the order.
+    compatible_manylinux_tags = [
+        tag
+        for tag in reversed(MANYLINUX_TAGS)
+        if _glibc_version_from_manylinux_tag(tag) <= latest_supported_glibc_version
+    ]
+    return compatible_manylinux_tags
 
 
 REQUIREMENT_PATTERN = re.compile(

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -44,9 +44,9 @@ if TYPE_CHECKING:
 # NB: in principle these depend on the glibc on the machine creating the conda env.
 # We use tags supported by manylinux Docker images, which are likely the most common
 # in practice, see https://github.com/pypa/manylinux/blob/main/README.rst#docker-images.
-
 # NOTE: Keep the max in sync with the default value used in virtual_packages.py
 MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17", "_2_24", "_2_28"]
+
 # This needs to be updated periodically as new macOS versions are released.
 MACOS_VERSION = (13, 4)
 
@@ -74,6 +74,8 @@ class PlatformEnv(Env):
             arch = "x86_64"
 
         if system == "linux":
+            # Summary of the manylinux tag story:
+            # <https://github.com/conda/conda-lock/pull/566#discussion_r1421745745>
             compatible_manylinux_tags = _compute_compatible_manylinux_tags(
                 platform_virtual_packages=platform_virtual_packages
             )

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -207,7 +207,8 @@ def default_virtual_package_repodata(cuda_version: str = "11.4") -> FakeRepoData
     )
     repodata.add_package(archspec_ppc64le, subdirs=["linux-ppc64le"])
 
-    glibc_virtual = FakePackage(name="__glibc", version="2.17")
+    # NOTE: Keep this in sync with the MANYLINUX_TAGS maximum in pypi_solver.py
+    glibc_virtual = FakePackage(name="__glibc", version="2.28")
     repodata.add_package(
         glibc_virtual, subdirs=["linux-aarch64", "linux-ppc64le", "linux-64"]
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-vrsx -n auto"
+addopts = "--doctest-modules -vrsx -n auto"
 flake8-max-line-length = 105
 flake8-ignore = ["docs/* ALL", "conda_lock/_version.py ALL"]
 filterwarnings = "ignore::DeprecationWarning"

--- a/tests/test-pip-respects-glibc-version/environment.yml
+++ b/tests/test-pip-respects-glibc-version/environment.yml
@@ -1,0 +1,8 @@
+# environment.yml
+channels:
+  - conda-forge
+
+dependencies:
+  - pip
+  - pip:
+    - cryptography

--- a/tests/test-pip-respects-glibc-version/virtual-packages.yml
+++ b/tests/test-pip-respects-glibc-version/virtual-packages.yml
@@ -1,0 +1,4 @@
+subdirs:
+  linux-64:
+    packages:
+      __glibc: "2.17"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2444,11 +2444,12 @@ def test_pip_finds_recent_manylinux_wheels(
     manylinux_version = [int(each) for each in manylinux_match.groups()]
     # Make sure the manylinux wheel was built with glibc > 2.17 as a
     # non-regression test for #517
-    assert manylinux_version > [2, 17]
+    assert manylinux_version == [2, 17]
 
 
 def test_manylinux_tags():
     from packaging.version import Version
+
     MANYLINUX_TAGS = pypi_solver.MANYLINUX_TAGS
 
     # The irregular tags should come at the beginning:
@@ -2464,8 +2465,9 @@ def test_manylinux_tags():
     # Verify that the default repodata uses the highest glibc version
     default_repodata = default_virtual_package_repodata()
     glibc_versions_in_default_repodata: Set[Version] = {
-        Version(package.version) for package in default_repodata.packages_by_subdir
-        if package.name=="__glibc"
+        Version(package.version)
+        for package in default_repodata.packages_by_subdir
+        if package.name == "__glibc"
     }
     max_glibc_version_from_manylinux_tags = versions[-1]
     assert glibc_versions_in_default_repodata == {max_glibc_version_from_manylinux_tags}

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2444,7 +2444,7 @@ def test_pip_finds_recent_manylinux_wheels(
     manylinux_version = [int(each) for each in manylinux_match.groups()]
     # Make sure the manylinux wheel was built with glibc > 2.17 as a
     # non-regression test for #517
-    assert manylinux_version == [2, 17]
+    assert manylinux_version > [2, 17]
 
 
 def test_manylinux_tags():
@@ -2505,7 +2505,7 @@ def test_pip_respects_glibc_version(
     manylinux_version = [int(each) for each in manylinux_match.groups()]
     # Make sure the manylinux wheel was built with glibc <= 2.17
     # since that is what the virtual package spec requires
-    assert manylinux_version <= [2, 17]
+    assert manylinux_version == [2, 17]
 
 
 def test_parse_environment_file_with_pip_and_platform_selector():

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2230,9 +2230,9 @@ def test_default_virtual_package_input_hash_stability():
     vpr = default_virtual_package_repodata()
 
     expected = {
-        "linux-64": "dbd71bccc4b3be81038e44b1f14891ccec40a6d70a43cfe02295fc77a2ea9eb5",
-        "linux-aarch64": "023611fb84c00fb5aaeddde1e0ac62e6ae007aecf6f69ccb5dbfc3cd6d945436",
-        "linux-ppc64le": "8533a7bd0e950f7b085eeef7686d2c4895e84b8ffdbfba6d62863072ac41090c",
+        "linux-64": "a949aac83da089258ce729fcd54dc0a3a1724ea325d67680d7a6d7cc9c0f1d1b",
+        "linux-aarch64": "f68603a3a28dbb03d20a25e1dacda3c42b6acc8a93bd31e13c4956115820cfa6",
+        "linux-ppc64le": "ababb6bc556ac8c9e27a499bf9b83b5757f6ded385caa0c3d7bf3f360dfe358d",
         "osx-64": "b7eebe4be0654740f67e3023f2ede298f390119ef225f50ad7e7288ea22d5c93",
         "osx-arm64": "cc82018d1b1809b9aebacacc5ed05ee6a4318b3eba039607d2a6957571f8bf2b",
         "win-64": "44239e9f0175404e62e4a80bb8f4be72e38c536280d6d5e484e52fa04b45c9f6",


### PR DESCRIPTION
PR #541 added support for finding wheels with GLIBC 2.28. However, as rightly pointed out in that PR:
"Note this could pose an issue if the glibc on the machine you are doing conda lock install does not have a recent enough glibc"

This PR aims to solve this issue by propagating the GLIBC version specified through the virtual package spec to Conda all the way down to the pypi solver.

To make all tests pass, the default GLIBC version is also raised to 2.28. We could alternatively keep it fixed and provide a virtual-packages.yml file for the test in PR #541 but it feels like both "defaults" should be the same (for pip and conda).
