### PR TITLE
Synchronize pip indentation with conda env export

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -672,7 +672,7 @@ def render_lockfile_for_platform(  # noqa: C901
             [
                 "  - pip:",
                 *(
-                    f"    - {format_pip_requirement(dep, platform, direct=False)}"
+                    f"      - {format_pip_requirement(dep, platform, direct=False)}"
                     for dep in pip_deps
                 ),
             ]


### PR DESCRIPTION
This is a minor change but it synchronizes the indentation of the pip dependencies with the output of `conda env export`. It makes it easier to compare `conda-lock` env files with exports of real conda environments.

Indentation in `conda env export` is determined by the `ruamel.yaml` configuration in `conda.common.serialize`: e.g. https://github.com/conda/conda/blob/ff330a1807d34870e60a9b8d3540695587845296/conda/common/serialize.py#L20.

### Commands

```bat
conda-lock -f environment.yml -p win-64
conda-lock render -k env -p win-64
conda-lock install -n lock-test
conda env export -n lock-test > env-export.yml
```

### `environment.yml`

```yml
name: lock-test
channels:
  - conda-forge
  - nodefaults
dependencies:
  - python =3.12
  - pip:
      - click
```

### `conda-win-64.lock.yml`

```yml
channels:
  - conda-forge
dependencies:
  - bzip2=1.0.8=hcfcfb64_5
  - ca-certificates=2023.11.17=h56e8100_0
  - libexpat=2.5.0=h63175ca_1
  - libffi=3.4.2=h8ffe710_5
  - libsqlite=3.44.2=hcfcfb64_0
  - libzlib=1.2.13=hcfcfb64_5
  - openssl=3.2.0=hcfcfb64_1
  - pip=23.3.2=pyhd8ed1ab_0
  - python=3.12.0=h2628c8c_0_cpython
  - setuptools=68.2.2=pyhd8ed1ab_0
  - tk=8.6.13=h5226925_1
  - tzdata=2023c=h71feb2d_0
  - ucrt=10.0.22621.0=h57928b3_0
  - vc=14.3=hcf57466_18
  - vc14_runtime=14.38.33130=h82b7239_18
  - vs2015_runtime=14.38.33130=hcb4865c_18
  - wheel=0.42.0=pyhd8ed1ab_0
  - xz=5.2.6=h8d14728_0
  - pip:
    - click === 8.1.7 --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
    - colorama === 0.4.6 --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
```

### `environment.yml`

```yml
name: lock-test
channels:
  - conda-forge
dependencies:
  - bzip2=1.0.8=hcfcfb64_5
  - ca-certificates=2023.11.17=h56e8100_0
  - libexpat=2.5.0=h63175ca_1
  - libffi=3.4.2=h8ffe710_5
  - libsqlite=3.44.2=hcfcfb64_0
  - libzlib=1.2.13=hcfcfb64_5
  - openssl=3.2.0=hcfcfb64_1
  - pip=23.3.2=pyhd8ed1ab_0
  - python=3.12.0=h2628c8c_0_cpython
  - setuptools=68.2.2=pyhd8ed1ab_0
  - tk=8.6.13=h5226925_1
  - tzdata=2023c=h71feb2d_0
  - ucrt=10.0.22621.0=h57928b3_0
  - vc=14.3=hcf57466_18
  - vc14_runtime=14.38.33130=h82b7239_18
  - vs2015_runtime=14.38.33130=hcb4865c_18
  - wheel=0.42.0=pyhd8ed1ab_0
  - xz=5.2.6=h8d14728_0
  - pip:
      - click==8.1.7
      - colorama==0.4.6
prefix: C:\Users\jmyatt\.conda\envs\lock-test
```
