### PR TITLE
Replace unnecessary Popen with subprocess.run

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -51,8 +51,8 @@ from conda_lock.conda_solver import solve_conda
 from conda_lock.errors import MissingEnvVarError, PlatformValidationError
 from conda_lock.invoke_conda import (
     PathLike,
-    _invoke_conda,
     determine_conda_executable,
+    invoke_conda,
     is_micromamba,
 )
 from conda_lock.lockfile import (
@@ -204,7 +204,7 @@ def do_conda_install(
     file: pathlib.Path,
     copy: bool,
 ) -> None:
-    _conda = partial(_invoke_conda, conda, prefix, name, check_call=True)
+    _conda = partial(invoke_conda, conda, prefix, name, check_call=True)
 
     kind = "env" if file.name.endswith(".yml") else "explicit"
 


### PR DESCRIPTION
#581 raised the issue of I/O deadlock with our use of `subprocess.Popen` and proposed solving this with threads. In this PR I take a step back and suggest that `subprocess.Popen` is unnecessary and can be replaced with `subprocess.run`. This simplifies the subprocess call and obviates the need for threads.