### PR TITLE
Reenable testing with Conda

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from conda_lock.invoke_conda import PathLike, _ensureconda
 @pytest.fixture(
     scope="session",
     params=[
-        pytest.param("conda", marks=pytest.mark.skip(reason="slow")),
+        pytest.param("conda"),
         pytest.param("mamba"),
         pytest.param("micromamba"),
     ],


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I hope now that conda uses the mamba solver by default that the tests will not be so absurdly slow. Also, it was dangerous disabling those tests. I never wanted to do it over an extended period.