### PR TITLE
Increase minimum ensureconda version for py3.12 compatibility

### DIFF
--- a/conda_lock/invoke_conda.py
+++ b/conda_lock/invoke_conda.py
@@ -8,10 +8,10 @@ import subprocess
 import tempfile
 import threading
 
-from distutils.version import LooseVersion
 from typing import IO, Dict, Iterator, List, Optional, Sequence, Union
 
 from ensureconda.api import determine_micromamba_version, ensureconda
+from packaging.version import Version
 
 from conda_lock.models.channel import Channel
 
@@ -57,7 +57,7 @@ def determine_conda_executable(
     for candidate in _determine_conda_executable(conda_executable, mamba, micromamba):
         if candidate is not None:
             if is_micromamba(candidate):
-                if determine_micromamba_version(str(candidate)) < LooseVersion("0.17"):
+                if determine_micromamba_version(str(candidate)) < Version("0.17"):
                     mamba_root_prefix()
             return candidate
     raise RuntimeError("Could not find conda (or compatible) executable")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # conda-lock dependencies
     "click >=8.0",
     "click-default-group",
-    "ensureconda >=1.3",
+    "ensureconda >=1.4.4",
     "gitpython >=3.1.30",
     "jinja2",
     "pydantic >=1.10",


### PR DESCRIPTION
Prior to ensureconda v1.4.4 distutils is used, which was removed in python 3.12. This prevents conda-lock running under python newer than 3.11, so the minimum version of ensureconda is increased.

Fixes https://github.com/conda/conda-lock/issues/542
Fixes https://github.com/conda/conda-lock/issues/596

The fix involves switching from distutils.version to packaging.version from the [packaging package](https://pypi.org/project/packaging/), which is maintained by the pypa.

The conda-lock.yml files will need regenerating after this PR.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
