### PR TITLE
Replace distutils.LooseVersion with packaging.Version

### DIFF
--- a/conda_lock/invoke_conda.py
+++ b/conda_lock/invoke_conda.py
@@ -8,10 +8,10 @@ import subprocess
 import tempfile
 import threading
 
-from distutils.version import LooseVersion
 from typing import IO, Dict, Iterator, List, Optional, Sequence, Union
 
 from ensureconda.api import determine_micromamba_version, ensureconda
+from packaging.version import Version
 
 from conda_lock.models.channel import Channel
 
@@ -57,7 +57,7 @@ def determine_conda_executable(
     for candidate in _determine_conda_executable(conda_executable, mamba, micromamba):
         if candidate is not None:
             if is_micromamba(candidate):
-                if determine_micromamba_version(str(candidate)) < LooseVersion("0.17"):
+                if determine_micromamba_version(str(candidate)) < Version("0.17"):
                     mamba_root_prefix()
             return candidate
     raise RuntimeError("Could not find conda (or compatible) executable")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "ensureconda >=1.3",
     "gitpython >=3.1.30",
     "jinja2",
+    "packaging",
     "pydantic >=1.10",
     "pyyaml >= 5.1",
     'tomli; python_version<"3.11"',


### PR DESCRIPTION
distutils was removed in python 3.12, so this is needed for conda-lock to work beyond python 3.11.

Fixes https://github.com/conda/conda-lock/issues/596

Will require the conda-lock.yml files regenerating due to the updated dependency.