### PR TITLE
Catch CalledProcessErrors from both subprocess and Poetry

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -17,6 +17,9 @@ import yaml
 from typing_extensions import TypedDict
 
 from conda_lock.interfaces.vendored_conda import MatchSpec
+from conda_lock.interfaces.vendored_poetry import (
+    CalledProcessError as PoetryCalledProcessError,
+)
 from conda_lock.invoke_conda import (
     PathLike,
     _get_conda_flags,
@@ -367,7 +370,7 @@ def solve_specs_for_arch(
 
     try:
         proc.check_returncode()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, PoetryCalledProcessError):
         try:
             err_json = json.loads(proc.stdout)
             try:
@@ -486,7 +489,7 @@ def update_specs_for_arch(
 
             try:
                 proc.check_returncode()
-            except subprocess.CalledProcessError as exc:
+            except (subprocess.CalledProcessError, PoetryCalledProcessError) as exc:
                 err_json = json.loads(proc.stdout)
                 raise RuntimeError(
                     f"Could not lock the environment for platform {platform}: {err_json.get('message')}"

--- a/conda_lock/interfaces/vendored_poetry.py
+++ b/conda_lock/interfaces/vendored_poetry.py
@@ -12,10 +12,12 @@ from conda_lock._vendor.poetry.puzzle import Solver as PoetrySolver
 from conda_lock._vendor.poetry.repositories.pool import Pool
 from conda_lock._vendor.poetry.repositories.pypi_repository import PyPiRepository
 from conda_lock._vendor.poetry.repositories.repository import Repository
+from conda_lock._vendor.poetry.utils._compat import CalledProcessError
 from conda_lock._vendor.poetry.utils.env import Env
 
 
 __all__ = [
+    "CalledProcessError",
     "Chooser",
     "Env",
     "Factory",

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -56,6 +56,9 @@ from conda_lock.errors import (
     PlatformValidationError,
 )
 from conda_lock.interfaces.vendored_conda import MatchSpec
+from conda_lock.interfaces.vendored_poetry import (
+    CalledProcessError as PoetryCalledProcessError,
+)
 from conda_lock.invoke_conda import is_micromamba, reset_conda_pkgs_dir
 from conda_lock.lockfile import parse_conda_lock_file
 from conda_lock.lockfile.v2prelim.models import (
@@ -1815,7 +1818,7 @@ def conda_supports_env(conda_exe: str):
         subprocess.check_call(
             [conda_exe, "env"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, PoetryCalledProcessError):
         return False
     return True
 


### PR DESCRIPTION
The vendored Poetry has the capacity to monkeypatch a bunch of subprocess stuff. This ensures that when a `CalledProcessError` occurs from Poetry that we handle it as expected.