### PR TITLE
Add explicit `setuptools` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "jinja2",
     "pydantic >=1.10",
     "pyyaml >= 5.1",
+    "setuptools",
     'tomli; python_version<"3.11"',
     "typing-extensions",
     # conda dependencies


### PR DESCRIPTION
Without setuptools, conda-lock fails with `ModuleNotFoundError: No module named 'distutils'` as reported in #607

Closes #607