### PR TITLE
fix: Ensure that content hashes are updated for an existing lock file when re-locking

### DIFF
--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -65,7 +65,7 @@ class Lockfile(StrictModel):
 
         # Resort the conda packages topologically
         final_package = self._toposort(package)
-        return Lockfile(package=final_package, metadata=other.metadata | self.metadata)
+        return Lockfile(package=final_package, metadata=self.metadata | other.metadata)
 
     def toposort_inplace(self) -> None:
         self.package = self._toposort(self.package)

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2744,7 +2744,7 @@ def test_when_merging_lockfiles_content_hashes_are_updated(
         platforms=["linux-64"],
     )
 
-    def get_content_hashes_for_lock_file(lock_file: Path) -> dict[str, str]:
+    def get_content_hashes_for_lock_file(lock_file: Path) -> typing.Dict[str, str]:
         lock_file_dict = yaml.safe_load(lock_file.read_text())
         return lock_file_dict["metadata"]["content_hash"]
 


### PR DESCRIPTION
### Description

This addresses https://github.com/conda/conda-lock/issues/617 by making the changes described in [this section](https://github.com/conda/conda-lock/issues/617#:~:text=A%20possible%20location%20for%20the%20bug).

### Testing

I added an end-to-end test which failed before making the operative change and now passes 🎉 .  My only uncertainty is if we feel comfortable hijacking the lock file fakes provided by `test-update` for this.

CC @maresb for review