### PR TITLE
Fix mypy precheck failures

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import pathlib
-import shlex
 import subprocess
 import sys
 import tempfile
@@ -338,19 +337,7 @@ def solve_specs_for_arch(
         "--dry-run",
         "--json",
     ]
-    conda_flags = os.environ.get("CONDA_FLAGS")
-    if conda_flags:
-        args.extend(shlex.split(conda_flags))
-    if channels:
-        args.append("--override-channels")
-
-    for channel in channels:
-        args.extend(["--channel", channel.env_replaced_url()])
-        if channel.url == "defaults" and platform in {"win-64", "win-32"}:
-            # msys2 is a windows-only channel that conda automatically
-            # injects if the host platform is Windows. If our host
-            # platform is not Windows, we need to add it manually
-            args.extend(["--channel", "msys2"])
+    args.extend(_get_conda_flags(channels=channels, platform=platform))
     args.extend(specs)
     logger.info("%s using specs %s", platform, specs)
     proc = subprocess.run(  # noqa: UP022  # Poetry monkeypatch breaks capture_output

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -346,7 +346,7 @@ def solve_specs_for_arch(
 
     for channel in channels:
         args.extend(["--channel", channel.env_replaced_url()])
-        if channel == "defaults" and platform in {"win-64", "win-32"}:
+        if channel.url == "defaults" and platform in {"win-64", "win-32"}:
             # msys2 is a windows-only channel that conda automatically
             # injects if the host platform is Windows. If our host
             # platform is not Windows, we need to add it manually

--- a/conda_lock/invoke_conda.py
+++ b/conda_lock/invoke_conda.py
@@ -194,7 +194,7 @@ def _get_conda_flags(channels: Sequence[Channel], platform: str) -> List[str]:
 
     for channel in channels:
         args.extend(["--channel", channel.env_replaced_url()])
-        if channel == "defaults" and platform in {"win-64", "win-32"}:
+        if channel.url == "defaults" and platform in {"win-64", "win-32"}:
             # msys2 is a windows-only channel that conda automatically
             # injects if the host platform is Windows. If our host
             # platform is not Windows, we need to add it manually

--- a/conda_lock/invoke_conda.py
+++ b/conda_lock/invoke_conda.py
@@ -198,6 +198,7 @@ def _get_conda_flags(channels: Sequence[Channel], platform: str) -> List[str]:
             # msys2 is a windows-only channel that conda automatically
             # injects if the host platform is Windows. If our host
             # platform is not Windows, we need to add it manually
+            # when using micromamba.
             args.extend(["--channel", "msys2"])
     return args
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The precommit hook is failing in https://github.com/conda/conda-lock/pull/626 (among other places) with these errors:

```
conda_lock/invoke_conda.py:197: error: Non-overlapping equality check (left operand type: "Channel", right operand type: "Literal['defaults']")  [comparison-overlap]
conda_lock/conda_solver.py:349: error: Non-overlapping equality check (left operand type: "Channel", right operand type: "Literal['defaults']")  [comparison-overlap]
```

I'm not a Python expert but I think the problem is we're comparing a `Channel` with a string, and equality isn't implemented for those two types. We could either just compare the `url` field or turn the `"defaults"` string into a channel, not sure which is preferred.