### PR TITLE
Add support for pip hash checking

### DIFF
--- a/conda_lock/interfaces/vendored_poetry.py
+++ b/conda_lock/interfaces/vendored_poetry.py
@@ -5,6 +5,7 @@ from conda_lock._vendor.poetry.core.packages import (
 )
 from conda_lock._vendor.poetry.core.packages import URLDependency as PoetryURLDependency
 from conda_lock._vendor.poetry.core.packages import VCSDependency as PoetryVCSDependency
+from conda_lock._vendor.poetry.core.packages.utils.link import Link
 from conda_lock._vendor.poetry.factory import Factory
 from conda_lock._vendor.poetry.installation.chooser import Chooser
 from conda_lock._vendor.poetry.installation.operations.uninstall import Uninstall
@@ -21,6 +22,7 @@ __all__ = [
     "Chooser",
     "Env",
     "Factory",
+    "Link",
     "PoetryDependency",
     "PoetryPackage",
     "PoetryProjectPackage",

--- a/conda_lock/models/lock_spec.py
+++ b/conda_lock/models/lock_spec.py
@@ -29,6 +29,7 @@ class VersionedDependency(_BaseDependency):
     version: str
     build: Optional[str] = None
     conda_channel: Optional[str] = None
+    hash: Optional[str] = None
 
 
 class URLDependency(_BaseDependency):

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -4,7 +4,7 @@ import warnings
 
 from pathlib import Path
 from posixpath import expandvars
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
 from urllib.parse import urldefrag, urlsplit, urlunsplit
 
 from clikit.api.io.flags import VERY_VERBOSE
@@ -406,7 +406,7 @@ def _get_url(link: Link) -> str:
 
 class _HashChooser:
     def __init__(
-        self, link: Link, dependency: PoetryDependency | PoetryDependencyWithHash
+        self, link: Link, dependency: Union[PoetryDependency, PoetryDependencyWithHash]
     ):
         self.link = link
         self.dependency = dependency

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -415,12 +415,9 @@ class _HashChooser:
         return self._get_hash_from_dependency() or self._get_hash_from_link()
 
     def _get_hash_from_dependency(self) -> Optional[HashModel]:
-        if self._dependency_provides_hash():
+        if isinstance(self.dependency, PoetryDependencyWithHash):
             return self.dependency.get_hash_model()
         return None
-
-    def _dependency_provides_hash(self) -> bool:
-        return isinstance(self.dependency, PoetryDependencyWithHash)
 
     def _get_hash_from_link(self) -> HashModel:
         hashes: Dict[str, str] = {}

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -4,7 +4,7 @@ import warnings
 
 from pathlib import Path
 from posixpath import expandvars
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, FrozenSet, List, Literal, Optional, Tuple, Union
 from urllib.parse import urldefrag, urlsplit, urlunsplit
 
 from clikit.api.io.flags import VERY_VERBOSE
@@ -12,6 +12,7 @@ from clikit.io import ConsoleIO, NullIO
 from packaging.tags import compatible_tags, cpython_tags, mac_platforms
 from packaging.version import Version
 
+from conda_lock._vendor.poetry.core.semver import VersionConstraint
 from conda_lock.interfaces.vendored_poetry import (
     Chooser,
     Env,
@@ -280,9 +281,33 @@ def parse_pip_requirement(requirement: str) -> Optional[Dict[str, str]]:
 
 
 class PoetryDependencyWithHash(PoetryDependency):
-    def __init__(self, *args, hash: Optional[str] = None, **kwargs) -> None:
+    def __init__(
+        self,
+        name,  # type: str
+        constraint,  # type: Union[str, VersionConstraint]
+        optional=False,  # type: bool
+        category="main",  # type: str
+        allows_prereleases=False,  # type: bool
+        extras=None,  # type: Optional[Union[List[str], FrozenSet[str]]]
+        source_type=None,  # type: Optional[str]
+        source_url=None,  # type: Optional[str]
+        source_reference=None,  # type: Optional[str]
+        source_resolved_reference=None,  # type: Optional[str]
+        hash: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            name,
+            constraint,
+            optional=optional,
+            category=category,
+            allows_prereleases=allows_prereleases,
+            extras=extras,  # type: ignore  # upstream type hint is wrong
+            source_type=source_type,
+            source_url=source_url,
+            source_reference=source_reference,
+            source_resolved_reference=source_resolved_reference,
+        )
         self.hash = hash
-        super().__init__(*args, **kwargs)
 
     def get_hash_model(self) -> Optional[HashModel]:
         if self.hash:

--- a/tests/test-pip-hash-checking/environment.yml
+++ b/tests/test-pip-hash-checking/environment.yml
@@ -1,0 +1,8 @@
+# environment.yml
+channels:
+  - conda-forge
+
+dependencies:
+  - pip
+  - pip:
+    - flit-core === 3.9.0 --hash=sha256:1234


### PR DESCRIPTION
### Description

Fix #624 by

1. Adding support for pip's `--hash` option in the requirement parser, for example 
```
- pip:
    - my_module === 1.2.3 --hash=sha256:1234
```
2. Using that hash to create a lockfile

### Questions

Is this going into the right direction? And some more specific questions:

1. The unit test is mostly copied from other another test. Should this be factorized?
2. This solution only works for a single hash. The [documentation](https://pip.pypa.io/en/stable/topics/secure-installs/#multiple-hashes-per-package) states that you can specify multiple hashes for the same package, for example for different platforms. As far as I can see this is not supported by conda-lock's hash model. But maybe it's not needed, because conda-lock supports different platforms anyway.
3. I created two new subclasses which hold the hash, mostly because I didn't want to break anything. But I'm not sure if that's the best approach.
4. I'm not sure how to resolve the mypy issue in `pypi_solver.py` (`PoetryDependency` not having the `get_hash_model` method). I agree with mypy that the solution is not really consistent, because some dependencies still carry the hash in their URL. Maybe `PoetryURLDependency` and `PoetryVCSDependency` could be extended with a `get_hash_model` method as well?




