### PR TITLE
Fix failing mypy check

### DIFF
--- a/tests/test_pip_repositories.py
+++ b/tests/test_pip_repositories.py
@@ -92,6 +92,7 @@ def mock_private_pypi(private_package_tar: Path, request: pytest.FixtureRequest)
         def _parse_auth(request: requests.Request) -> Tuple[str, str]:
             url = urlparse(request.url)
             if url.username:
+                assert url.password is not None
                 return url.username, url.password
             header = request.headers.get("Authorization")
             if not header or not header.startswith("Basic"):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

```
tests/test_pip_repositories.py:95: error: Incompatible return value type (got "tuple[str, str | None]", expected "tuple[str, str]")  [return-value]
```

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
