### PR TITLE
Sort BaseLockedDependency.dependencies when alpha-sorting a Lockfile

### DIFF
--- a/conda_lock/lockfile/v1/models.py
+++ b/conda_lock/lockfile/v1/models.py
@@ -68,7 +68,7 @@ class BaseLockedDependency(StrictModel):
         return v
 
     def alphasort_inplace(self) -> None:
-        self.dependencies = {k: v for k, v in sorted(self.dependencies)}
+        self.dependencies = {k: self.dependencies[k] for k in sorted(self.dependencies)}
 
 
 class LockedDependency(BaseLockedDependency):

--- a/conda_lock/lockfile/v1/models.py
+++ b/conda_lock/lockfile/v1/models.py
@@ -67,6 +67,9 @@ class BaseLockedDependency(StrictModel):
             raise ValueError("conda package hashes must use MD5")
         return v
 
+    def alphasort_inplace(self) -> None:
+        self.dependencies = {k: v for k, v in sorted(self.dependencies)}
+
 
 class LockedDependency(BaseLockedDependency):
     optional: bool

--- a/conda_lock/lockfile/v1/models.py
+++ b/conda_lock/lockfile/v1/models.py
@@ -67,9 +67,6 @@ class BaseLockedDependency(StrictModel):
             raise ValueError("conda package hashes must use MD5")
         return v
 
-    def alphasort_inplace(self) -> None:
-        self.dependencies = {k: self.dependencies[k] for k in sorted(self.dependencies)}
-
 
 class LockedDependency(BaseLockedDependency):
     optional: bool

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -72,6 +72,8 @@ class Lockfile(StrictModel):
 
     def alphasort_inplace(self) -> None:
         self.package.sort(key=lambda d: d.key())
+        for p in self.package:
+            p.alphasort_inplace()
 
     def filter_virtual_packages_inplace(self) -> None:
         self.package = [

--- a/conda_lock/lockfile/v2prelim/models.py
+++ b/conda_lock/lockfile/v2prelim/models.py
@@ -71,9 +71,14 @@ class Lockfile(StrictModel):
         self.package = self._toposort(self.package)
 
     def alphasort_inplace(self) -> None:
+        # Sort the packages themselves by key (conda/pip, name, platform)
         self.package.sort(key=lambda d: d.key())
         for p in self.package:
-            p.alphasort_inplace()
+            # Also ensure that the dependencies of each package are sorted
+            # <https://github.com/conda/conda-lock/pull/654#issuecomment-2198453427>
+            p.dependencies = {
+                name: spec for name, spec in sorted(p.dependencies.items())
+            }
 
     def filter_virtual_packages_inplace(self) -> None:
         self.package = [


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

When writing a conda-lock.yml file, the `package.dependencies` are not sorted. This can cause more lines to change than strictly needed when e.g. adding a new package that does not alter any existing packages. This help with merge conflicts etc.

I was unsure of the ethos around testing in this repo, but very happy to add tests as needed with some guidance 🙂 
