### PR TITLE
take into account branch, tag or rev on git dependencies

### DIFF
--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -282,7 +282,16 @@ def parse_poetry_pyproject_toml(
                 version = poetry_version_spec
 
             if "git" in depattrs and url is not None:
-                url, rev = unpack_git_url(url)
+                url, at_rev = unpack_git_url(url)
+                rev = (
+                    depattrs.get("branch") or depattrs.get("tag") or depattrs.get("rev")
+                )
+                if rev is None:
+                    rev = at_rev
+                elif at_rev is not None and at_rev != rev:
+                    raise ValueError(
+                        f"git dependency {depname} has conflicting rev ({rev}) and url@rev {at_rev} specified"
+                    )
                 dependencies.append(
                     VCSDependency(
                         name=name,


### PR DESCRIPTION
### Problem

conda-lock does not take into account `rev`, `branch` or `tag` for a git dependency in pyprojet.toml
See reference in Poetry documentation about specifying the git revision: https://python-poetry.org/docs/dependency-specification/#git-dependencies

It only considers the revision when expressed in the url as `url@rev`

### Fix
Checks both the url and the `branch`, `tag` or `rev` field. Raises an exception in case the information is specified both ways with different values.
