### PR TITLE
Do a strict pkg meta check @ release CD workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Test wheels
       run: |
-        python -m twine check dist/*
+        python -m twine check --strict dist/*
       shell: bash
 
     - name: Upload dist files for publication


### PR DESCRIPTION
### Description

The previously used non-strict mode of `twine check` ignores a subset of problems with the README rendering. It is the best practice to have `--strict`. Running it in normal CI allows catching issues way before the time comes to make a release. It's rather unpleasant to get upload failures at the last moment.