### PR TITLE
Show default values in CLI

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1145,7 +1145,7 @@ TLogLevel = Union[
 ]
 
 
-@main.command("lock")
+@main.command("lock", context_settings={"show_default": True})
 @click.option(
     "--conda", default=None, help="path (or name) of the conda/mamba executable to use."
 )
@@ -1414,7 +1414,7 @@ DEFAULT_INSTALL_OPT_DEV = True
 DEFAULT_INSTALL_OPT_LOCK_FILE = pathlib.Path(DEFAULT_LOCKFILE_NAME)
 
 
-@main.command("install")
+@main.command("install", context_settings={"show_default": True})
 @click.option(
     "--conda", default=None, help="path (or name) of the conda/mamba executable to use."
 )
@@ -1552,7 +1552,7 @@ def install(
             install_func(file=lockfile)
 
 
-@main.command("render")
+@main.command("render", context_settings={"show_default": True})
 @click.option(
     "--dev-dependencies/--no-dev-dependencies",
     is_flag=True,


### PR DESCRIPTION
Closes #658

```
$ conda-lock lock --help
Usage: conda-lock lock [OPTIONS]

  Generate fully reproducible lock files for conda environments.

  By default, a multi-platform lock file is written to conda-lock.yml.

  When choosing the "explicit" or "env" kind, lock files are written to
  conda-{platform}.lock. These filenames can be customized using the
  --filename-template argument. The following tokens are available:

      platform: The platform this lock file was generated for (conda subdir).
      dev-dependencies: Whether or not dev dependencies are included in this lock file.
      input-hash: A sha256 hash of the lock file input specification.
      version: The version of conda-lock used to generate this lock file.
      timestamp: The approximate timestamp of the output file in ISO8601 basic format.

Options:
  --conda TEXT                    path (or name) of the conda/mamba executable
                                  to use.
  --mamba / --no-mamba            don't attempt to use or install mamba.
                                  [default: mamba]
  --micromamba / --no-micromamba  don't attempt to use or install micromamba.
                                  [default: no-micromamba]
  -p, --platform TEXT             generate lock files for the following
                                  platforms
  -c, --channel TEXT              Override the channels to use when solving
                                  the environment. These will replace the
                                  channels as listed in the various source
                                  files.
  --dev-dependencies / --no-dev-dependencies
                                  include dev dependencies in the lockfile
                                  (where applicable)  [default: dev-
                                  dependencies]
  -f, --file PATH                 path to a conda environment specification(s)
                                  [default: environment.yml]
  -k, --kind TEXT                 Kind of lock file(s) to generate [should be
                                  one of 'lock', 'explicit', or 'env'].
                                  [default: lock]
  --filename-template TEXT        Template for single-platform (explicit, env)
                                  lock file names. Filename must include
                                  {platform} token, and must not end in
                                  '.yml'. For a full list and description of
                                  available tokens, see the command help text.
                                  [default: conda-{platform}.lock]
  --lockfile TEXT                 Path to a conda-lock.yml to create or update
                                  [default: conda-lock.yml]
  --strip-auth                    Strip the basic auth credentials from the
                                  lockfile.
  -e, --extras, --category TEXT   When used in conjunction with input sources
                                  that support extras/categories
                                  (pyproject.toml) will add the deps from
                                  those extras to the render specification
  --filter-categories, --filter-extras
                                  In conjunction with extras this will prune
                                  out dependencies that do not have the extras
                                  specified when loading files.
  --check-input-hash              Check existing input hashes in lockfiles
                                  before regenerating lock files.  If no files
                                  were updated exit with exit code 4.
                                  Incompatible with --strip-auth
  --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                  Log level.  [default: INFO]
  --pdb                           Drop into a postmortem debugger if conda-
                                  lock crashes
  --virtual-package-spec PATH     Specify a set of virtual packages to use.
  --update TEXT                   Packages to update to their latest versions.
                                  If empty, update all.
  --pypi_to_conda_lookup_file TEXT
                                  Location of the lookup file containing Pypi
                                  package names to conda names.
  --md, --metadata [timestamp|git_sha|git_user_name|git_user_email|input_md5|input_sha]
                                  Metadata fields to include in lock-file
  --with-cuda TEXT                Specify cuda version to use in virtual
                                  packages. Avoids warning about implicit
                                  acceptance of cuda dependencies. Ignored if
                                  virtual packages are specified.
  --without-cuda                  Disable cuda in virtual packages. Prevents
                                  accepting cuda variants of packages. Ignored
                                  if virtual packages are specified.
  --mdy, --metadata-yaml, --metadata-json PATH
                                  YAML or JSON file(s) containing structured
                                  metadata to add to metadata section of the
                                  lockfile.
  --help                          Show this message and exit.
```