### PR TITLE
Split virtual-package repo from LockSpecification

### DIFF
--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -75,7 +75,6 @@ def _parse_source_files(
 def make_lock_spec(
     *,
     src_files: List[pathlib.Path],
-    virtual_package_repo: FakeRepoData,
     channel_overrides: Optional[Sequence[str]] = None,
     pip_repository_overrides: Optional[Sequence[str]] = None,
     platform_overrides: Optional[Sequence[str]] = None,
@@ -131,6 +130,5 @@ def make_lock_spec(
         channels=channels,
         pip_repositories=pip_repositories,
         sources=aggregated_lock_spec.sources,
-        virtual_package_repo=virtual_package_repo,
         allow_pypi_requests=aggregated_lock_spec.allow_pypi_requests,
     )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

In preparation for exporting `LockSpecification`s in #664

This is a refactor so I don't expect it to be controversial.

The goal here is simply to remove `virtual_package_repo` from `conda_lock.models.lock_spec.LockSpecification`. The reason is that the virtual packages are only really used when computing the content hash. So while I think one could make a principled argument either way that the virtual packages are or are not part of the lock specification, there seems to me like a very practical split of the functionality. Most of the time `virtual_package_repo` is simply tagging along for the ride. It's nice to not need to pass around extra data when it's unneeded, and especially to make it clearer when it's needed.

So all I do here is:

1. Remove `virtual_package_repo` from `LockSpecification`
2. Add it as a function argument in the locations where it needs to be passed around.
3. Switch to a more logical ordering of operations when generating the lockfile so that the virtual package repo is only created on disk when the dependencies are actually locked.

Already we can see that the `make_lock_spec` doesn't need `virtual_package_repo` so I can simplify some of the tests by removing the unused `virtual_package_repo` context manager.