### PR TITLE
Update .gitignore for pixi

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@
 *.ico binary
 # Treat vendor folder as vendored and generated
 conda_lock/_vendor/** linguist-vendored linguist-generated
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ site/
 filelock
 .coverage
 .micromamba/
+.pixi/
+# Make ad-hoc experimentation easier; remove these once we settle on a config
+pixi.lock
+pixi.toml


### PR DESCRIPTION
### Description

This will help us to experiment with using pixi for conda-lock.

We definitely want `.pixi/` to be ignored.

We will also make a `pixi.lock` and `pixi.toml` but to ease switching branches we add them to `.gitignore` on a temporary basis.