### PR TITLE
Add support for PEP 508 environment markers

### DIFF
--- a/conda_lock/interfaces/vendored_poetry_markers.py
+++ b/conda_lock/interfaces/vendored_poetry_markers.py
@@ -1,0 +1,20 @@
+from conda_lock._vendor.poetry.core.version.markers import (
+    AnyMarker,
+    BaseMarker,
+    EmptyMarker,
+    MarkerUnion,
+    MultiMarker,
+    SingleMarker,
+    parse_marker,
+)
+
+
+__all__ = [
+    "AnyMarker",
+    "BaseMarker",
+    "EmptyMarker",
+    "MarkerUnion",
+    "MultiMarker",
+    "SingleMarker",
+    "parse_marker",
+]

--- a/conda_lock/models/lock_spec.py
+++ b/conda_lock/models/lock_spec.py
@@ -19,6 +19,7 @@ class _BaseDependency(StrictModel):
     manager: Literal["conda", "pip"] = "conda"
     category: str = "main"
     extras: List[str] = []
+    markers: Optional[str] = None
 
     @validator("extras")
     def sorted_extras(cls, v: List[str]) -> List[str]:
@@ -55,6 +56,7 @@ class PoetryMappedDependencySpec(StrictModel):
     url: Optional[str]
     manager: Literal["conda", "pip"]
     extras: List
+    markers: Optional[str]
     poetry_version_spec: Optional[str]
 
 

--- a/conda_lock/src_parser/markers.py
+++ b/conda_lock/src_parser/markers.py
@@ -1,0 +1,77 @@
+"""Evaluate PEP 508 environment markers.
+
+Environment markers are expressions such as `sys_platform == 'darwin'` that can
+be attached to dependency specifications.
+
+<https://www.python.org/dev/peps/pep-0508/#environment-markers>
+"""
+
+import warnings
+
+from typing import Set, Union
+
+from conda_lock.interfaces.vendored_poetry_markers import (
+    AnyMarker,
+    BaseMarker,
+    EmptyMarker,
+    MarkerUnion,
+    MultiMarker,
+    SingleMarker,
+    parse_marker,
+)
+from conda_lock.pypi_solver import PlatformEnv
+
+
+def get_names(marker: Union[BaseMarker, str]) -> Set[str]:
+    """Extract all environment marker names from a marker expression.
+
+    >>> names = get_names(
+    ...     "python_version < '3.9' and os_name == 'nt' or os_name == 'posix'"
+    ... )
+    >>> sorted(names)
+    ['os_name', 'python_version']
+    """
+    if isinstance(marker, str):
+        marker = parse_marker(marker)
+    if isinstance(marker, SingleMarker):
+        return {marker.name}
+    if isinstance(marker, (MarkerUnion, MultiMarker)):
+        return set.union(*[get_names(m) for m in marker.markers])
+    if isinstance(marker, (AnyMarker, EmptyMarker)):
+        return set()
+    raise NotImplementedError(f"Unknown marker type: {marker!r}")
+
+
+def evaluate_marker(marker: Union[BaseMarker, str, None], platform: str) -> bool:
+    """Evaluate a marker expression for a given platform.
+
+    This is intended to be used for parsing lock specifications, before the Python
+    version is known, so markers like `python_version` are not supported.
+    If the marker contains any unsupported names, a warning is issued, and the
+    corresponding clause will evaluate to `True`.
+
+    >>> evaluate_marker("sys_platform == 'darwin'", "osx-arm64")
+    True
+    >>> evaluate_marker("sys_platform == 'darwin'", "linux-64")
+    False
+    >>> evaluate_marker(None, "win-64")
+    True
+
+    # Unsupported names evaluate to True
+    >>> evaluate_marker("python_version < '0' and implementation_name == 'q'", "win-64")
+    True
+    """
+    if marker is None:
+        return True
+    if isinstance(marker, str):
+        marker = parse_marker(marker)
+    env = PlatformEnv(platform=platform)
+    marker_env = env.get_marker_env()
+    names = get_names(marker)
+    supported_names = set(marker_env.keys())
+    if not names <= supported_names:
+        warnings.warn(
+            f"Marker '{marker}' contains environment markers: "
+            f"{names - supported_names}. Only {supported_names} are supported."
+        )
+    return marker.validate(marker_env)

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -462,7 +462,17 @@ def parse_python_requirement(
     category: str = "main",
     normalize_name: bool = True,
 ) -> Dependency:
-    """Parse a requirements.txt like requirement to a conda spec"""
+    """Parse a requirements.txt like requirement to a conda spec.
+
+    >>> parse_python_requirement("my_package")  # doctest: +NORMALIZE_WHITESPACE
+    VersionedDependency(name='my-package', manager='conda', category='main', extras=[],
+        markers=None, version='*', build=None, conda_channel=None, hash=None)
+
+    >>> parse_python_requirement("My_Package[extra]==1.23")  # doctest: +NORMALIZE_WHITESPACE
+    VersionedDependency(name='my-package', manager='conda', category='main',
+        extras=['extra'], markers=None, version='==1.23', build=None,
+        conda_channel=None, hash=None)
+    """
     parsed_req = parse_requirement_specifier(requirement)
     name = canonicalize_pypi_name(parsed_req.name)
     collapsed_version = str(parsed_req.specifier)

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -468,6 +468,7 @@ def parse_python_requirement(
             name=conda_dep_name,
             source=url,
             manager=manager,
+            category=category,
             vcs="git",
             rev=rev,
         )

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2652,18 +2652,22 @@ def test_platformenv_linux_platforms():
     ] + ["linux_x86_64"]
 
     # Check that we get the default platforms when no virtual packages are specified
-    e = PlatformEnv("3.12", "linux-64")
+    e = PlatformEnv(python_version="3.12", platform="linux-64")
     assert e._platforms == all_expected_platforms
 
     # Check that we get the default platforms when the virtual packages are empty
-    e = PlatformEnv("3.12", "linux-64", platform_virtual_packages={})
+    e = PlatformEnv(
+        python_version="3.12", platform="linux-64", platform_virtual_packages={}
+    )
     assert e._platforms == all_expected_platforms
 
     # Check that we get the default platforms when the virtual packages are nonempty
     # but don't include __glibc
     platform_virtual_packages = {"x.bz2": {"name": "not_glibc"}}
     e = PlatformEnv(
-        "3.12", "linux-64", platform_virtual_packages=platform_virtual_packages
+        python_version="3.12",
+        platform="linux-64",
+        platform_virtual_packages=platform_virtual_packages,
     )
     assert e._platforms == all_expected_platforms
 
@@ -2672,7 +2676,9 @@ def test_platformenv_linux_platforms():
     default_repodata = default_virtual_package_repodata()
     platform_virtual_packages = default_repodata.all_repodata["linux-64"]["packages"]
     e = PlatformEnv(
-        "3.12", "linux-64", platform_virtual_packages=platform_virtual_packages
+        python_version="3.12",
+        platform="linux-64",
+        platform_virtual_packages=platform_virtual_packages,
     )
     assert e._platforms == all_expected_platforms
 
@@ -2684,7 +2690,9 @@ def test_platformenv_linux_platforms():
         if record["name"] != "__glibc"
     }
     e = PlatformEnv(
-        "3.12", "linux-64", platform_virtual_packages=platform_virtual_packages
+        python_version="3.12",
+        platform="linux-64",
+        platform_virtual_packages=platform_virtual_packages,
     )
     assert e._platforms == all_expected_platforms
 
@@ -2701,7 +2709,9 @@ def test_platformenv_linux_platforms():
         name="__glibc", version="2.17"
     )
     e = PlatformEnv(
-        "3.12", "linux-64", platform_virtual_packages=platform_virtual_packages
+        python_version="3.12",
+        platform="linux-64",
+        platform_virtual_packages=platform_virtual_packages,
     )
     assert e._platforms == restricted_platforms
 
@@ -2711,7 +2721,9 @@ def test_platformenv_linux_platforms():
     )
     with pytest.warns(UserWarning):
         e = PlatformEnv(
-            "3.12", "linux-64", platform_virtual_packages=platform_virtual_packages
+            python_version="3.12",
+            platform="linux-64",
+            platform_virtual_packages=platform_virtual_packages,
         )
     assert e._platforms == restricted_platforms
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import pytest
+
+from conda_lock.src_parser import make_lock_spec
+
+
+ENVIRONMENT_YAML = """
+channels:
+    - conda-forge
+    - nodefaults
+dependencies:
+    - pip
+    - pip:
+        - cowsay; sys_platform == 'darwin'
+platforms:
+    - osx-64
+    - osx-arm64
+    - linux-64
+"""
+
+POETRY_PYPROJECT = """
+[tool.poetry]
+name = "conda-lock-test-poetry"
+version = "0.0.1"
+description = ""
+authors = ["conda-lock"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+cowsay = {version = "*", markers = "sys_platform == 'darwin'"}
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.conda-lock]
+platforms = [
+    "osx-64",
+    "osx-arm64",
+    "linux-64",
+]
+"""
+
+HATCH_PYPROJECT = """
+[build-system]
+requires = ["hatchling >=1.25.0,<2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "conda-lock-test-hatch"
+version = "0.0.1"
+dependencies = ["cowsay; sys_platform == 'darwin'"]
+
+[tool.conda-lock]
+platforms = [
+    "osx-64",
+    "osx-arm64",
+    "linux-64",
+]
+"""
+
+
+@pytest.fixture(
+    params=[
+        (ENVIRONMENT_YAML, "environment.yml"),
+        (POETRY_PYPROJECT, "pyproject.toml"),
+        (HATCH_PYPROJECT, "pyproject.toml"),
+    ],
+    ids=["environment.yml", "poetry", "hatch"],
+)
+def cowsay_src_file(request, tmp_path: Path):
+    contents, filename = request.param
+    src_file = tmp_path / filename
+    src_file.write_text(contents)
+    return src_file
+
+
+def test_sys_platform_marker(cowsay_src_file):
+    lock_spec = make_lock_spec(src_files=[cowsay_src_file])
+    dependencies = lock_spec.dependencies
+    platform_has_cowsay = {
+        platform: any(dep.name == "cowsay" for dep in platform_deps)
+        for platform, platform_deps in dependencies.items()
+    }
+    assert platform_has_cowsay == {
+        "osx-64": True,
+        "osx-arm64": True,
+        "linux-64": False,
+    }


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Environment markers are expressions such as `sys_platform == 'darwin'` that can
be attached to dependency specifications.

<https://www.python.org/dev/peps/pep-0508/#environment-markers>


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
