### PR TITLE
Use a quicker example for the channel-inversion test

### DIFF
--- a/tests/test-channel-inversion/environment.yaml
+++ b/tests/test-channel-inversion/environment.yaml
@@ -4,9 +4,8 @@ channels:
   # In this case we have the channel order as recommended by rapids ai for
   # installing cudf, but we want to force getting cuda-python from conda-forge
   # instead of from the nvidia channel which would normally have higher priority
-  - rapidsai
-  - nvidia
   - conda-forge
+  - defaults
 dependencies:
-  - cudf
-  - conda-forge::cuda-python
+  - zlib
+  - defaults::libgomp

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -1665,22 +1665,30 @@ def test_poetry_version_parsing_constraints(
 def test_run_with_channel_inversion(
     monkeypatch: "pytest.MonkeyPatch", channel_inversion: Path, mamba_exe: str
 ):
-    """Given that the cuda_python package is available from a few channels
-    and three of those channels listed
-    and with conda-forge listed as the lowest priority channel
-    and with the cuda_python dependency listed as "conda-forge::cuda_python",
-    ensure that the lock file parse picks up conda-forge as the channel and not one of the higher priority channels
+    """Given that the libgomp package is available from a few channels
+    and two of those channels listed
+    and with defaults listed as the lowest priority channel
+    and with the libgomp dependency listed as "defaults::libgomp",
+    ensure that the lock file parse picks up "defaults" as the channel and not
+    the higher priority conda-forge channel.
     """
     monkeypatch.chdir(channel_inversion.parent)
     run_lock([channel_inversion], conda_exe=mamba_exe, platforms=["linux-64"])
     lockfile = parse_conda_lock_file(channel_inversion.parent / DEFAULT_LOCKFILE_NAME)
     for package in lockfile.package:
-        if package.name == "cuda-python":
+        if package.name == "zlib":
             ms = MatchSpec(package.url)  # pyright: ignore
             assert ms.get("channel") == "conda-forge"
             break
     else:
-        raise ValueError("cuda-python not found!")
+        raise ValueError("zlib not found!")
+    for package in lockfile.package:
+        if package.name == "libgomp":
+            ms = MatchSpec(package.url)  # pyright: ignore
+            assert ms.get("channel") == "defaults"
+            break
+    else:
+        raise ValueError("libgomp not found!")
 
 
 def _make_spec(name: str, constraint: str = "*"):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This test case has an average duration of 141 seconds, compared with the next-highest durations in the 70-90s range for `test_run_lock*`.

AFAICT we just need to check that the lockfile references a package with an out-of-order channel when that channel is specified. The newer example should accomplish this with a much lower overhead.  

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
