### PR TITLE
Fix test that fails when cache is deleted

### DIFF
--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2752,7 +2752,12 @@ def test_parse_environment_file_with_pip_and_platform_selector():
 
 
 def test_pip_full_whl_url(
-    tmp_path: Path, conda_exe: str, monkeypatch: "pytest.MonkeyPatch"
+    tmp_path: Path,
+    conda_exe: str,
+    monkeypatch: "pytest.MonkeyPatch",
+    # If the cache is cleared under this test, it can cause an error message:
+    # E       FileNotFoundError: [Errno 2] No such file or directory: '/Users/runner/Library/Caches/pypoetry-conda-lock/artifacts/5a/51/bb/896565e2c84dc024b41e43536c67cef3618b17b0daa532d87a72054dca/requests-2.31.0-py3-none-any.whl'
+    cleared_poetry_cache: None,
 ):
     """Ensure that we can specify full wheel URL in the environment file."""
 

--- a/tests/test_pip_repositories.py
+++ b/tests/test_pip_repositories.py
@@ -1,7 +1,5 @@
 import base64
 import os
-import shutil
-import sys
 import tarfile
 
 from io import BytesIO
@@ -13,9 +11,6 @@ import pytest
 import requests
 import requests_mock
 
-from filelock import FileLock
-
-from conda_lock._vendor.poetry.locations import DEFAULT_CACHE_DIR
 from conda_lock.conda_lock import DEFAULT_LOCKFILE_NAME, run_lock
 from conda_lock.lockfile import parse_conda_lock_file
 from tests.test_conda_lock import clone_test_dir
@@ -135,25 +130,6 @@ def configure_auth(monkeypatch):
     monkeypatch.setenv("PIP_PASSWORD", _PRIVATE_REPO_PASSWORD)
 
 
-@pytest.fixture()
-def cleared_poetry_cache(tmp_path_factory, testrun_uid: str):
-    """Ensure no concurrency for tests that rely on the cache being cleared"""
-    # testrun_uid comes from xdist <https://stackoverflow.com/a/62765653>
-    # The idea for using FileLock with the base temp directory comes from
-    # <https://pytest-xdist.readthedocs.io/en/latest/how-to.html#making-session-scoped-fixtures-execute-only-once>
-    root_tmp_dir = tmp_path_factory.getbasetemp().parent
-    testrun_lockfile = root_tmp_dir / f".conda_lock_pytest_{testrun_uid}.lock"
-    with FileLock(testrun_lockfile):
-        # Use `pytest -s` to see these messages
-        print(
-            f"Clearing {DEFAULT_CACHE_DIR} based on lock {testrun_lockfile}",
-            file=sys.stderr,
-        )
-        clear_poetry_cache()
-        yield
-        print(f"Releasing lock {testrun_lockfile}", file=sys.stderr)
-
-
 def test_it_uses_pip_repositories_with_env_var_substitution(
     monkeypatch: "pytest.MonkeyPatch",
     conda_exe: str,
@@ -197,18 +173,3 @@ def test_it_uses_pip_repositories_with_env_var_substitution(
         "Password environment variable was not respected, See full lock-file:\n"
         + lockfile_content
     )
-
-
-def clear_poetry_cache() -> None:
-    # We are going to rmtree the cache directory. Let's be extra careful to make
-    # sure we only delete a directory named "pypoetry-conda-lock" or one of its
-    # subdirectories.
-    to_delete = DEFAULT_CACHE_DIR.resolve()
-    assert to_delete.name == "pypoetry-conda-lock" or (
-        to_delete.parent.name == "pypoetry-conda-lock" and to_delete.name == "Cache"
-    )
-    # Do another independent check that triggers even if we're in optimized mode
-    if "pypoetry-conda-lock" in to_delete.parts:
-        shutil.rmtree(DEFAULT_CACHE_DIR, ignore_errors=True)
-    else:
-        raise RuntimeError(f"Refusing to delete {to_delete} as it does not look right")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This change should hopefully prevent this failure resulting from the cache being concurrently deleted by other parallel tests:

https://github.com/conda/conda-lock/actions/runs/10810137369/job/29986724241

```python
_________________________ test_pip_full_whl_url[conda] _________________________
[gw2] darwin -- Python 3.12.5 /Users/runner/micromamba/envs/conda-lock-dev/bin/python3.12

tmp_path = PosixPath('/private/var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/pytest-of-runner/pytest-0/popen-gw2/test_pip_full_whl_url_conda_0')
conda_exe = PosixPath('/Users/runner/micromamba/envs/conda-lock-dev/bin/conda')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1079cde80>

    def test_pip_full_whl_url(
        tmp_path: Path, conda_exe: str, monkeypatch: "pytest.MonkeyPatch"
    ):
        """Ensure that we can specify full wheel URL in the environment file."""
    
        env_file = clone_test_dir("test-pip-full-url", tmp_path).joinpath("environment.yml")
        monkeypatch.chdir(env_file.parent)
>       run_lock(
            [env_file],
            conda_exe=str(conda_exe),
            platforms=["linux-64"],
        )

/Users/runner/work/conda-lock/conda-lock/tests/test_conda_lock.py:2761: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/runner/work/conda-lock/conda-lock/conda_lock/conda_lock.py:1113: in run_lock
    make_lock_files(
/Users/runner/work/conda-lock/conda-lock/conda_lock/conda_lock.py:391: in make_lock_files
    fresh_lock_content = create_lockfile_from_spec(
/Users/runner/work/conda-lock/conda-lock/conda_lock/conda_lock.py:836: in create_lockfile_from_spec
    deps = _solve_for_arch(
/Users/runner/work/conda-lock/conda-lock/conda_lock/conda_lock.py:761: in _solve_for_arch
    pip_deps = solve_pypi(
/Users/runner/work/conda-lock/conda-lock/conda_lock/pypi_solver.py:549: in solve_pypi
    result = s.solve(use_latest=to_update)
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/puzzle/solver.py:71: in solve
    packages, depths = self._solve()
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/puzzle/solver.py:154: in _solve
    result = resolve_version(self._package, self._provider)
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/mixology/__init__.py:18: in resolve_version
    return solver.solve()
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/mixology/version_solver.py:175: in solve
    next = self._choose_package_version()
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/mixology/version_solver.py:514: in _choose_package_version
    package = self._provider.complete_package(package)
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/puzzle/provider.py:568: in complete_package
    self.search_for_direct_origin_dependency(dep)
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/puzzle/provider.py:257: in search_for_direct_origin_dependency
    package = self._search_for_url(dependency)
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/puzzle/provider.py:372: in _search_for_url
    package = self._direct_origin.get_package_from_url(dependency.url)
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/packages/direct_origin.py:85: in get_package_from_url
    {"file": link.filename, "hash": "sha256:" + get_file_hash(artifact)}
/Users/runner/work/conda-lock/conda-lock/conda_lock/_vendor/poetry/utils/helpers.py:328: in get_file_hash
    with path.open("rb") as fp:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/Users/runner/Library/Caches/pypoetry-conda-lock/artifacts/5a/51/bb/896565e2c84dc024b41e43536c67cef3618b17b0daa532d87a72054dca/requests-2.31.0-py3-none-any.whl')
mode = 'rb', buffering = -1, encoding = None, errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
E       FileNotFoundError: [Errno 2] No such file or directory: '/Users/runner/Library/Caches/pypoetry-conda-lock/artifacts/5a/51/bb/896565e2c84dc024b41e43536c67cef3618b17b0daa532d87a72054dca/requests-2.31.0-py3-none-any.whl'

/Users/runner/micromamba/envs/conda-lock-dev/lib/python3.12/pathlib.py:1013: FileNotFoundError
```

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
