### PR TITLE
Refactor lock command and fix an edge case

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -358,6 +358,9 @@ def make_lock_files(  # noqa: C901
         platforms_already_locked: List[str] = []
         if original_lock_content is not None:
             platforms_already_locked = list(original_lock_content.metadata.platforms)
+            if update is not None:
+                # Narrow `update` sequence to list for mypy
+                update = list(update)
             update_spec = UpdateSpecification(
                 locked=original_lock_content.package, update=update
             )

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1619,6 +1619,7 @@ def render(
     # bail out if we do not encounter the lockfile
     lock_file = pathlib.Path(lock_file)
     if not lock_file.exists():
+        print(f"ERROR: Lockfile {lock_file} does not exist.\n\n", file=sys.stderr)
         print(ctx.get_help())
         sys.exit(1)
 

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1208,7 +1208,6 @@ TLogLevel = Union[
     "-f",
     "--file",
     "files",
-    default=DEFAULT_FILES,
     type=click.Path(),
     multiple=True,
     help="path to a conda environment specification(s)",
@@ -1366,7 +1365,7 @@ def lock(
     metadata_enum_choices = set(MetadataOption(md) for md in metadata_choices)
 
     # bail out if we do not encounter the default file if no files were passed
-    if ctx.get_parameter_source("files") == click.core.ParameterSource.DEFAULT:  # type: ignore
+    if len(files) == 0:
         candidates = DEFAULT_FILES.copy()
         candidates += [f.with_name(f.name.replace(".yml", ".yaml")) for f in candidates]
         for f in candidates:
@@ -1376,6 +1375,7 @@ def lock(
             logger.error("No source files provided.")
             print(ctx.get_help())
             sys.exit(1)
+        files = DEFAULT_FILES.copy()
 
     if pdb:
         sys.excepthook = _handle_exception_post_mortem

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1060,6 +1060,10 @@ def _detect_lockfile_kind(path: pathlib.Path) -> TKindAll:
 def reconstruct_environment_files_from_lockfile(
     lockfile_path: Optional[pathlib.Path],
 ) -> List[pathlib.Path]:
+    """No sources were specified on the CLI, so try to read them from the lockfile.
+
+    If none are found, then fall back to the default files.
+    """
     is_lockfile_specified = lockfile_path is not None
     if lockfile_path is None:
         lockfile_path = pathlib.Path(DEFAULT_LOCKFILE_NAME)
@@ -1127,7 +1131,7 @@ def run_lock(
     metadata_yamls: Sequence[pathlib.Path] = (),
     strip_auth: bool = False,
 ) -> None:
-    if environment_files == DEFAULT_FILES:
+    if len(environment_files) == 0:
         environment_files = reconstruct_environment_files_from_lockfile(lockfile_path)
 
     _conda_exe = determine_conda_executable(
@@ -1375,7 +1379,7 @@ def lock(
             logger.error("No source files provided.")
             print(ctx.get_help())
             sys.exit(1)
-        files = DEFAULT_FILES.copy()
+    environment_files = [pathlib.Path(file) for file in files]
 
     if pdb:
         sys.excepthook = _handle_exception_post_mortem
@@ -1396,7 +1400,7 @@ def lock(
     extras_ = set(extras)
     lock_func = partial(
         run_lock,
-        environment_files=[pathlib.Path(file) for file in files],
+        environment_files=environment_files,
         conda_exe=conda,
         platforms=platform,
         mamba=mamba,

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1351,6 +1351,7 @@ def lock(
             if f.exists():
                 break
         else:
+            logger.error("No source files provided.")
             print(ctx.get_help())
             sys.exit(1)
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -30,7 +30,6 @@ from freezegun import freeze_time
 
 from conda_lock import __version__, pypi_solver
 from conda_lock.conda_lock import (
-    DEFAULT_FILES,
     DEFAULT_LOCKFILE_NAME,
     _add_auth_to_line,
     _add_auth_to_lockfile,
@@ -1446,7 +1445,7 @@ def test_run_lock_with_locked_environment_files(
     run_lock([pre_environment], conda_exe="mamba")
     make_lock_files = MagicMock()
     monkeypatch.setattr("conda_lock.conda_lock.make_lock_files", make_lock_files)
-    run_lock(DEFAULT_FILES, conda_exe=conda_exe, update=["pydantic"])
+    run_lock([], conda_exe=conda_exe, update=["pydantic"])
     src_files = make_lock_files.call_args.kwargs["src_files"]
 
     assert [p.resolve() for p in src_files] == [
@@ -1473,9 +1472,7 @@ def test_run_lock_relative_source_path(
     assert Path(locked_environment) == Path("../sources/environment.yaml")
     make_lock_files = MagicMock()
     monkeypatch.setattr("conda_lock.conda_lock.make_lock_files", make_lock_files)
-    run_lock(
-        DEFAULT_FILES, lockfile_path=lockfile, conda_exe=conda_exe, update=["pydantic"]
-    )
+    run_lock([], lockfile_path=lockfile, conda_exe=conda_exe, update=["pydantic"])
     src_files = make_lock_files.call_args.kwargs["src_files"]
     assert [p.resolve() for p in src_files] == [environment.resolve()]
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Before, when no lockfile was found by `conda-lock render` it would print the help and exit. Now it also prints a helpful error message that no lockfile was found.

Before, when no source files were found by `conda-lock lock` it would print the help and exit. Now it also prints a helpful error message that no source files were provided.

For the case when no source files are specified, the logic to reconstruct the environment files from a lockfile has been split into a helper function.

Several type hints for the Click function `lock` were incorrect, so these have been corrected. Some corresponding minor adjustments were also made to appease mypy.

Omitted CLI parameters are handled more explicitly for the lockfile path and source paths. In particular, we better distinguish the cases "no value provided" and "default value provided".

Related to the previous point, we now correctly handle the case of using CLI parameters to override the source files defined in a lockfile when the override coincides with the default value and consolidate the code for handling empty source files.


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
