### PR TITLE
Install conda-lock with pipx in integration tests for better isolation

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.8" ]
+        python-version: [ "3.8", "3.12" ]
     defaults:
       run:
         shell: bash -el {0}
@@ -50,7 +50,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install conda-lock
         run: |
-          pip install -e .
+          pip install pipx
+          pipx install -e .
       - name: run-test
         run: |
           conda-lock --log-level=DEBUG --mamba -f tests/gdal/environment.yml -p $CONDA_PLATFORM
@@ -114,7 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.8" ]
+        python-version: [ "3.8", "3.12" ]
     defaults:
       run:
         shell: bash -el {0}
@@ -126,7 +127,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install conda-lock
         run: |
-          pip install -e .
+          pip install pipx
+          pipx install -e .
       - name: Download lockfiles
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This reproduced the problem with `distutils` as reported in https://github.com/conda/conda-lock/issues/676#issuecomment-2350770774 until we rebased on #699, resolving the problem.

By using `pipx` we increase the isolation of conda-lock's environment, making it easier to detect dependency errors.


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
