### PR TITLE
Only run the publish job on releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' }}
     needs: build
     # Run this job in an isolated GHA environment containing the OIDC credentials.
     environment: release
@@ -54,5 +55,4 @@ jobs:
         name: dist-files
         path: dist
     - name: Publish a Python distribution to PyPI
-      if: ${{ github.event_name == 'release' }}
       uses: pypa/gh-action-pypi-publish@v1.10.1


### PR DESCRIPTION


<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This is causing the status of `main` to hang yellow because the publish job now runs in a protected environment that requires manual authorization.
<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
