### PR TITLE
Fix erroneous PyPI to Conda dep name conversion for PyPI deps

### DIFF
--- a/conda_lock/src_parser/environment_yaml.py
+++ b/conda_lock/src_parser/environment_yaml.py
@@ -76,7 +76,6 @@ def _parse_environment_file_for_platform(
                 spec,
                 manager="pip",
                 category=category,
-                normalize_name=False,
                 mapping_url=mapping_url,
             )
             if evaluate_marker(dependency.markers, platform):

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -445,7 +445,6 @@ def parse_python_requirement(
     mapping_url: str,
     manager: Literal["conda", "pip"] = "conda",
     category: str = "main",
-    normalize_name: bool = True,
 ) -> Dependency:
     """Parse a requirements.txt like requirement to a conda spec.
 
@@ -500,7 +499,7 @@ def parse_python_requirement(
     if conda_version:
         conda_version = ",".join(sorted(conda_version.split(",")))
 
-    if normalize_name:
+    if manager == "conda":
         conda_dep_name = pypi_name_to_conda_name(name, mapping_url=mapping_url)
     else:
         conda_dep_name = name

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -456,6 +456,23 @@ def parse_python_requirement(
     VersionedDependency(name='my-package', manager='conda', category='main', extras=[],
         markers=None, version='*', build=None, conda_channel=None, hash=None)
 
+    The PyPI name `build` will be translated to `python-build` for conda.
+    >>> parse_python_requirement(
+    ...     "build",
+    ...     mapping_url=DEFAULT_MAPPING_URL,
+    ... )  # doctest: +NORMALIZE_WHITESPACE
+    VersionedDependency(name='python-build', manager='conda', category='main',
+        extras=[], markers=None, version='*', build=None, conda_channel=None, hash=None)
+
+    No translation is done for `manager="pip"`.
+    >>> parse_python_requirement(
+    ...     "build",
+    ...     manager="pip",
+    ...     mapping_url=DEFAULT_MAPPING_URL,
+    ... )  # doctest: +NORMALIZE_WHITESPACE
+    VersionedDependency(name='build', manager='pip', category='main',
+        extras=[], markers=None, version='*', build=None, conda_channel=None, hash=None)
+
     >>> parse_python_requirement(
     ...     "My_Package[extra]==1.23",
     ...     mapping_url=DEFAULT_MAPPING_URL,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

When parsing PyPI deps from non-Poetry pyproject.toml files, we were converting the names to Conda even when we were keeping the dependencies as Python. This fixes that.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
