### PR TITLE
Use JSON version of the default PyPI mapping

### DIFF
--- a/conda_lock/lookup.py
+++ b/conda_lock/lookup.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Dict
 
 import requests
-import ruamel.yaml
 
 from filelock import FileLock, Timeout
 from packaging.utils import NormalizedName, canonicalize_name
@@ -45,6 +44,8 @@ def _get_pypi_lookup(mapping_url: str) -> Dict[NormalizedName, MappingEntry]:
     if url.endswith(".json"):
         lookup = json.loads(content)
     else:
+        import ruamel.yaml
+
         yaml = ruamel.yaml.YAML(typ="safe")
         lookup = yaml.load(content)
     load_duration = time.monotonic() - load_start

--- a/conda_lock/lookup.py
+++ b/conda_lock/lookup.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import time
 
@@ -18,7 +19,7 @@ from typing_extensions import TypedDict
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MAPPING_URL = "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/mappings/pypi/grayskull_pypi_mapping.yaml"
+DEFAULT_MAPPING_URL = "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/mappings/pypi/grayskull_pypi_mapping.json"
 
 
 class MappingEntry(TypedDict):
@@ -41,8 +42,11 @@ def _get_pypi_lookup(mapping_url: str) -> Dict[NormalizedName, MappingEntry]:
         content = Path(path).read_bytes()
     logger.debug("Parsing PyPI mapping")
     load_start = time.monotonic()
-    yaml = ruamel.yaml.YAML(typ="safe")
-    lookup = yaml.load(content)
+    if url.endswith(".json"):
+        lookup = json.loads(content)
+    else:
+        yaml = ruamel.yaml.YAML(typ="safe")
+        lookup = yaml.load(content)
     load_duration = time.monotonic() - load_start
     logger.debug(f"Loaded {len(lookup)} entries in {load_duration:.2f}s")
     # lowercase and kebabcase the pypi names

--- a/conda_lock/lookup.py
+++ b/conda_lock/lookup.py
@@ -5,7 +5,7 @@ import time
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict
+from typing import Dict, TypedDict
 
 import requests
 
@@ -13,7 +13,6 @@ from filelock import FileLock, Timeout
 from packaging.utils import NormalizedName, canonicalize_name
 from packaging.utils import canonicalize_name as canonicalize_pypi_name
 from platformdirs import user_cache_path
-from typing_extensions import TypedDict
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Description

This should save 3 seconds on each conda-lock invocation.

Parsing the YAML takes 3s, while loading the JSON takes about 30ms.

For backwards compatibility we keep the ability to parse YAML.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
