### PR TITLE
Revert one of the micromamba v2 workarounds

### DIFF
--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2594,20 +2594,13 @@ def test_fake_conda_env(conda_exe: str, conda_lock_yaml: Path):
             expected_channel = "conda-forge"
             expected_base_url = "https://conda.anaconda.org/conda-forge"
             if is_micromamba(conda_exe):
-                dist_name = env_package["dist_name"]
                 assert env_package["base_url"] in {
                     f"{expected_base_url}/{platform}",
                     expected_base_url,
-                    # <https://github.com/mamba-org/mamba/issues/3480>
-                    f"{expected_base_url}/{platform}/{dist_name}.conda",
-                    f"{expected_base_url}/{platform}/{dist_name}.tar.bz2",
                 }
                 assert env_package["channel"] in {
                     f"{expected_channel}/{platform}",
                     expected_channel,
-                    # <https://github.com/mamba-org/mamba/issues/3480>
-                    f"{expected_channel}/{platform}/{dist_name}.conda",
-                    f"{expected_channel}/{platform}/{dist_name}.tar.bz2",
                 }
             else:
                 assert env_package["base_url"] == expected_base_url


### PR DESCRIPTION
This reverts commit d27b97ed3b4c85ea50f537a25905d8ab6f63d4eb, "Allow for strange base_url and channel with micromamba2"

This was reported in https://github.com/mamba-org/mamba/issues/3480 and fixed in micromamba v2.0.2.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
