### PR TITLE
Minor bugfix: don't truncate the extension in conda-meta filenames

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -565,9 +565,10 @@ def fake_conda_environment(
             channel = urlunsplit(
                 (url.scheme, url.hostname, str(path.parent), None, None)
             )
-            while path.suffix in {".tar", ".bz2", ".gz", ".conda"}:
-                path = path.with_suffix("")
-            build = path.name.split("-")[-1]
+            truncated_path = path
+            while truncated_path.suffix in {".tar", ".bz2", ".gz", ".conda"}:
+                truncated_path = truncated_path.with_suffix("")
+            build = truncated_path.name.split("-")[-1]
             try:
                 build_number = int(build.split("_")[-1])
             except ValueError:
@@ -588,6 +589,6 @@ def fake_conda_environment(
             if dep.hash.sha256 is not None:
                 entry["sha256"] = dep.hash.sha256
 
-            with open(conda_meta / (path.name + ".json"), "w") as f:
+            with open(conda_meta / (truncated_path.name + ".json"), "w") as f:
                 json.dump(entry, f, indent=2)
         yield prefix

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2644,7 +2644,10 @@ def test_fake_conda_env(conda_exe: str, conda_lock_yaml: Path):
             else:
                 assert env_package["base_url"] == expected_base_url
                 assert env_package["channel"] == expected_channel
-            assert env_package["dist_name"] == f"{path.name[:-8]}"
+            expected_dist = path
+            while expected_dist.name.endswith((".tar", ".bz2", ".gz", ".conda")):
+                expected_dist = expected_dist.with_suffix("")
+            assert env_package["dist_name"] == expected_dist.name
             assert platform == path.parent.name
 
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2605,16 +2605,6 @@ def test_fake_conda_env(conda_exe: str, conda_lock_yaml: Path):
     with fake_conda_environment(
         lockfile_content.package, platform="linux-64"
     ) as prefix:
-        subprocess.call(
-            [
-                conda_exe,
-                "list",
-                "--debug",
-                "-p",
-                prefix,
-                "--json",
-            ]
-        )
         packages = json.loads(
             subprocess.check_output(
                 [


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Conda-lock constructs a fake `conda-meta` directory containing a .json metadata for each package in a lockfile. A typical .json looks like

```json
{
  "name": "astropy",
  "channel": "conda-forge",
  "url": "https://conda.anaconda.org/conda-forge/linux-64/astropy-5.0-py39hce5d2b2_0.tar.bz2",
  "md5": "5a2d9b5961e84cbbac615c2e3fb7e456",
  "build": "py39hce5d2b2_0",
  "build_number": 0,
  "version": "5.0",
  "subdir": "linux-64",
  "fn": "astropy-5.0-py39hce5d2b2_0.tar.bz2",
  "depends": [
    "importlib-metadata",
    "libgcc-ng >=9.4.0",
    "numpy >=1.19.5,<2.0a0",
    "packaging >=19.0",
    "pyerfa >=2.0",
    "python >=3.9,<3.10.0a0",
    "python_abi 3.9.* *_cp39",
    "pyyaml >=3.13"
  ]
}
```

Before this change, the `fn` entry was missing the `.tar.bz2` extension. This was leading to problems with micromamba v2 which apparently strengthened the validation logic a bit.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
