### PR TITLE
Add environment variables for conda/mamba/micromamba

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1193,17 +1193,22 @@ TLogLevel = Union[
 
 @main.command("lock", context_settings={"show_default": True})
 @click.option(
-    "--conda", default=None, help="path (or name) of the conda/mamba executable to use."
+    "--conda",
+    default=None,
+    help="path (or name) of the conda/mamba executable to use.",
+    envvar="CONDA_LOCK_CONDA",
 )
 @click.option(
     "--mamba/--no-mamba",
     default=HAVE_MAMBA,
     help="don't attempt to use or install mamba.",
+    envvar="CONDA_LOCK_MAMBA",
 )
 @click.option(
     "--micromamba/--no-micromamba",
     default=False,
     help="don't attempt to use or install micromamba.",
+    envvar="CONDA_LOCK_MICROMAMBA",
 )
 @click.option(
     "-p",
@@ -1453,17 +1458,22 @@ DEFAULT_INSTALL_OPT_LOCK_FILE = pathlib.Path(DEFAULT_LOCKFILE_NAME)
 
 @main.command("install", context_settings={"show_default": True})
 @click.option(
-    "--conda", default=None, help="path (or name) of the conda/mamba executable to use."
+    "--conda",
+    default=None,
+    help="path (or name) of the conda/mamba executable to use.",
+    envvar="CONDA_LOCK_CONDA",
 )
 @click.option(
     "--mamba/--no-mamba",
     default=DEFAULT_INSTALL_OPT_MAMBA,
     help="don't attempt to use or install mamba.",
+    envvar="CONDA_LOCK_MAMBA",
 )
 @click.option(
     "--micromamba/--no-micromamba",
     default=DEFAULT_INSTALL_OPT_MICROMAMBA,
     help="don't attempt to use or install micromamba.",
+    envvar="CONDA_LOCK_MICROMAMBA",
 )
 @click.option(
     "--copy",


### PR DESCRIPTION
### Description

Adds `CONDA_LOCK_CONDA`, `CONDA_LOCK_MAMBA`, and `CONDA_LOCK_MICROMAMBA` as per @scott-kausler's https://github.com/conda/conda-lock/issues/758#issuecomment-2540518096.

Example:

```bash
CONDA_LOCK_MICROMAMBA=1 CONDA_LOCK_MAMBA=0 conda-lock --log-level=DEBUG
```

and you should see a `micromamba` executable being used. Note that without setting `CONDA_LOCK_MAMBA=0` then if `mamba` is found then it takes precedence. (I'm not defending this behavior; open to PRs :wink:)