### PR TITLE
Allow to call `conda-lock -h` (argparse default) instead of `conda-lock --help`

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1191,8 +1191,10 @@ TLogLevel = Union[
     Literal["CRITICAL"],
 ]
 
+CONTEXT_SETTINGS = {"show_default": True, "help_option_names": ["--help", "-h"]}
 
-@main.command("lock", context_settings={"show_default": True, "help_option_names": ["--help", "-h"]})
+
+@main.command("lock", context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--conda",
     default=None,
@@ -1457,7 +1459,7 @@ DEFAULT_INSTALL_OPT_DEV = True
 DEFAULT_INSTALL_OPT_LOCK_FILE = pathlib.Path(DEFAULT_LOCKFILE_NAME)
 
 
-@main.command("install", context_settings={"show_default": True})
+@main.command("install", context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--conda",
     default=None,
@@ -1611,7 +1613,7 @@ def install(
             install_func(file=lockfile)
 
 
-@main.command("render", context_settings={"show_default": True})
+@main.command("render", context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--dev-dependencies/--no-dev-dependencies",
     is_flag=True,
@@ -1692,7 +1694,7 @@ def render(
     )
 
 
-@main.command("render-lock-spec", context_settings={"show_default": True})
+@main.command("render-lock-spec", context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--conda",
     default=None,

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1192,7 +1192,7 @@ TLogLevel = Union[
 ]
 
 
-@main.command("lock", context_settings={"show_default": True})
+@main.command("lock", context_settings={"show_default": True, "help_option_names": ["--help", "-h"]})
 @click.option(
     "--conda",
     default=None,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

After calling `conda-lock -h` MANY times I still fall for it. This adds it as an alias for `--help`.


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
