### PR TITLE
Fix an issue that caused transitive dependencies to not have categories

### DIFF
--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -124,6 +124,12 @@ def apply_categories(
             # `dask-core` as packages that are planned to be installed.
             planned_items = extract_planned_items(_seperator_munge_get(planned, item))
 
+            if item != name:
+                # Add item to deps *after* extracting dependencies otherwise we do not
+                # properly mark all transitive dependencies as part of the same
+                # category.
+                deps.add(item)
+
             for planned_item in planned_items:
                 todo.extend(
                     dep_name(
@@ -135,7 +141,6 @@ def apply_categories(
                 )
             if todo:
                 item = todo.pop(0)
-                deps.add(item)
             else:
                 break
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

In `apply_categories`, the logic was such that transitive dependencies were not considered and the category labels effectively did not propagate. This resulted in incomplete lock files

This fixes #730 although I am not 100% sure why the issue showed up so recently; it may be that the other fix around cateogries exacerbated this problem.
