### PR TITLE
Use build_string in build field in fake package

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,11 @@ subdirs:
     packages:
       __glibc: "2.17"
       __cuda: "11.4"
+      __archspec: "1 haswell"
   win-64:
     packages:
       __cuda: "11.4"
+      __archspec: "1 haswell"
 ```
 
 conda-lock will automatically use a `virtual-packages.yml` it finds in the the current working directory.  Alternatively one can be specified

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -37,9 +37,9 @@ class FakePackage(BaseModel):
     def to_repodata_entry(self) -> Tuple[str, Dict[str, Any]]:
         out = self.model_dump()
         if self.build_string:
-            build = f"{self.build_string}_{self.build_number}"
+            build = self.build_string
         else:
-            build = f"{self.build_number}"
+            build = str(self.build_number)
         out["depends"] = list(out["depends"])
         out["build"] = build
         fname = f"{self.name}-{self.version}-{build}.tar.bz2"

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -147,9 +147,11 @@ subdirs:
     packages:
       __glibc: "2.17"
       __cuda: "11.4"
+      __archspec: "1 haswell"
   win-64:
     packages:
       __cuda: "11.4"
+      __archspec: "1 haswell"
 ```
 
 conda-lock will automatically use a `virtual-packages.yml` it finds in the the current working directory.  Alternatively one can be specified

--- a/tests/test-archspec/virtual-packages.yaml
+++ b/tests/test-archspec/virtual-packages.yaml
@@ -1,0 +1,4 @@
+subdirs:
+  linux-64:
+    packages:
+      __archspec: "1 x86_64_v2"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2637,12 +2637,12 @@ def test_default_virtual_package_input_hash_stability():
     from conda_lock.virtual_package import default_virtual_package_repodata
 
     expected = {
-        "linux-64": "a949aac83da089258ce729fcd54dc0a3a1724ea325d67680d7a6d7cc9c0f1d1b",
-        "linux-aarch64": "f68603a3a28dbb03d20a25e1dacda3c42b6acc8a93bd31e13c4956115820cfa6",
-        "linux-ppc64le": "ababb6bc556ac8c9e27a499bf9b83b5757f6ded385caa0c3d7bf3f360dfe358d",
-        "osx-64": "b7eebe4be0654740f67e3023f2ede298f390119ef225f50ad7e7288ea22d5c93",
-        "osx-arm64": "cc82018d1b1809b9aebacacc5ed05ee6a4318b3eba039607d2a6957571f8bf2b",
-        "win-64": "44239e9f0175404e62e4a80bb8f4be72e38c536280d6d5e484e52fa04b45c9f6",
+        "linux-64": "ebfbb8130f916103373e6521bfb129825cded8b0c3e93f430cc834d8c3664244",
+        "linux-aarch64": "5418156c9b6c5ae92b8558087b5d39ee06c66b5ec405a91b4c7ee23d6cec41e2",
+        "linux-ppc64le": "7b111d5f69fb0bd81808d1a9272187ad719e5f03c63b3ebb600aca01355b8576",
+        "osx-64": "e2236a55963b8a15f6702e885eb44c7ce3f294c638cc91aa770e23435f77d18e",
+        "osx-arm64": "bb227bce8532d0eee9396306045e270525b110103f4c54be9ac35621baab3dcd",
+        "win-64": "1d34ea90abc99d31721cae03335543cbe16ad4e1eaa988e7a7f8563bda2f951d",
     }
 
     spec = LockSpecification(

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2123,6 +2123,7 @@ def test_solve_arch_transitive_deps():
         # Ensure that transitive dependencies are also properly tagged
         assert ipython_deps[0].categories == {"main"}
 
+
 def test_solve_x86_64_microarch_level_1():
     _conda_exe = determine_conda_executable(None, mamba=False, micromamba=False)
     channels = [Channel.from_string("conda-forge")]
@@ -2157,9 +2158,13 @@ def test_solve_x86_64_microarch_level_1():
                 virtual_package_repo=vpr,
                 mapping_url=DEFAULT_MAPPING_URL,
             )
-        
-        assert len(locked_deps) == 1
-        assert locked_deps[0].version == "1"
+
+        microarch_level_deps = [
+            dep for dep in locked_deps if dep.name == "_x86_64-microarch-level"
+        ]
+        assert len(microarch_level_deps) == 1
+        assert microarch_level_deps[0].version == "1"
+
 
 def test_solve_x86_64_microarch_level_2_exception():
     _conda_exe = determine_conda_executable(None, mamba=False, micromamba=False)
@@ -2196,6 +2201,7 @@ def test_solve_x86_64_microarch_level_2_exception():
                     virtual_package_repo=vpr,
                     mapping_url=DEFAULT_MAPPING_URL,
                 )
+
 
 def test_solve_x86_64_microarch_level_2_with_input_spec():
     from conda_lock.virtual_package import virtual_package_repo_from_specification
@@ -2236,8 +2242,12 @@ def test_solve_x86_64_microarch_level_2_with_input_spec():
                 mapping_url=DEFAULT_MAPPING_URL,
             )
 
-        assert len(locked_deps) == 1
-        assert locked_deps[0].version == "2"
+        microarch_level_deps = [
+            dep for dep in locked_deps if dep.name == "_x86_64-microarch-level"
+        ]
+        assert len(microarch_level_deps) == 1
+        assert microarch_level_deps[0].version == "2"
+
 
 def _check_package_installed(package: str, prefix: str, subdir: Optional[str] = None):
     files = list(glob(f"{prefix}/conda-meta/{package}-*.json"))


### PR DESCRIPTION
### Description

Concatenating the`build` field in a conda package as `{build_string}_{build_number}` is wrong and leads to wrong behaviors.

For example, running `conda-lock -f environment.yml` with
```yaml
# environment.yml
channels:
  - conda-forge
dependencies:
  - libblasfeo>=0.1.4.1
platforms:
  - linux-64
```
result in the following error:
```
{
    "solver_problems": [
        "nothing provides __archspec 1 core2 needed by _x86_64-microarch-level-1-0_core2"
    ],
    "success": false
}
```
The error occurs because `FakePackage(name="__archspec", version="1", build_string="x86_64")` ([see here](https://github.com/conda/conda-lock/blob/df4280c4562239b6a0aa23517416f0402726d80a/conda_lock/virtual_package.py#L195)) has the `build` field set to `x86_64_0` which leads to the error since it would expect `__archspec-1-x86_64.tar.bz2` (or `__archspec-1-core2.tar.bz2` as an alternative example) as a package instead of `__archspec-1-x86_64_0.tar.bz2`. This becomes especially critical, since the `_x86_64-microarch-level-*` packages need exact build fields for `__archspec`.

#### Edit 

Also added some test and added an example for `__archspec` in the docs.