### PR TITLE
Ensure `--check-input-hash` is respected when using `conda-lock lock --strip-auth --check-input-hash ...`

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1430,6 +1430,7 @@ def lock(
         channel_overrides=channel_overrides,
         kinds=kind,
         lockfile_path=None if lockfile is None else pathlib.Path(lockfile),
+        check_input_hash=check_input_hash,
         extras=extras_,
         virtual_package_spec=virtual_package_spec,
         with_cuda=with_cuda,
@@ -1450,9 +1451,7 @@ def lock(
                 lockfile_content = _strip_auth_from_lockfile(lockfile_content)
                 write_file(lockfile_content, os.path.join(filename_template_dir, file))
     else:
-        lock_func(
-            filename_template=filename_template, check_input_hash=check_input_hash
-        )
+        lock_func(filename_template=filename_template)
 
 
 DEFAULT_INSTALL_OPT_MAMBA = HAVE_MAMBA


### PR DESCRIPTION
### Description
When you use `conda-lock lock --strip-auth --check-input-hash` it always tries to re-lock the file. I found this because when trying to diagnose difference between local solve and CI - but that was a different matter.

I have attempted to fix this but I don't know how to test, or if there is a reason for it.