### PR TITLE
Add type annotations for `content_hash` computation

### DIFF
--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -2,7 +2,6 @@ import json
 import os
 import pathlib
 import tempfile
-import typing
 import warnings
 
 from contextlib import contextmanager

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -772,13 +772,12 @@ def _solve_for_arch(
         if "python" not in conda_deps:
             raise ValueError("Got pip specs without Python")
 
-        platform_virtual_packages = (
-            virtual_package_repo.all_repodata.get(platform, {"packages": None})[
-                "packages"
-            ]
-            if virtual_package_repo
-            else None
-        )
+        if not virtual_package_repo:
+            platform_virtual_packages = None
+        else:
+            platform_virtual_packages = virtual_package_repo.all_repodata.get(
+                platform, {"packages": None}
+            )["packages"]
 
         pip_deps = solve_pypi(
             pip_specs=requested_deps_by_name["pip"],

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -775,9 +775,10 @@ def _solve_for_arch(
         if not virtual_package_repo:
             platform_virtual_packages = None
         else:
-            platform_virtual_packages = virtual_package_repo.all_repodata.get(
+            metadata_for_platform = virtual_package_repo.all_repodata.get(
                 platform, {"packages": None}
-            )["packages"]
+            )
+            platform_virtual_packages = metadata_for_platform["packages"]
 
         pip_deps = solve_pypi(
             pip_specs=requested_deps_by_name["pip"],

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -771,6 +771,15 @@ def _solve_for_arch(
     if requested_deps_by_name["pip"]:
         if "python" not in conda_deps:
             raise ValueError("Got pip specs without Python")
+
+        platform_virtual_packages = (
+            virtual_package_repo.all_repodata.get(platform, {"packages": None})[
+                "packages"
+            ]
+            if virtual_package_repo
+            else None
+        )
+
         pip_deps = solve_pypi(
             pip_specs=requested_deps_by_name["pip"],
             use_latest=update_spec.update,
@@ -780,13 +789,7 @@ def _solve_for_arch(
             conda_locked={dep.name: dep for dep in conda_deps.values()},
             python_version=conda_deps["python"].version,
             platform=platform,
-            platform_virtual_packages=(
-                virtual_package_repo.all_repodata.get(platform, {"packages": None})[
-                    "packages"
-                ]
-                if virtual_package_repo
-                else None
-            ),
+            platform_virtual_packages=platform_virtual_packages,
             pip_repositories=pip_repositories,
             allow_pypi_requests=spec.allow_pypi_requests,
             strip_auth=strip_auth,

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -775,10 +775,8 @@ def _solve_for_arch(
         if not virtual_package_repo:
             platform_virtual_packages = None
         else:
-            metadata_for_platform = virtual_package_repo.all_repodata.get(
-                platform, {"packages": None}
-            )
-            platform_virtual_packages = metadata_for_platform["packages"]
+            metadata_for_platform = virtual_package_repo.all_repodata.get(platform, {})
+            platform_virtual_packages = metadata_for_platform.get("packages")
 
         pip_deps = solve_pypi(
             pip_specs=requested_deps_by_name["pip"],

--- a/conda_lock/content_hash_types.py
+++ b/conda_lock/content_hash_types.py
@@ -1,0 +1,92 @@
+"""Type definitions related to computing content hashes.
+
+There is incidentally also a lot of virtual package stuff here.
+"""
+
+from typing import (
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union,
+)
+
+from typing_extensions import NotRequired, TypeAlias, TypedDict
+
+
+# Use TypeAlias to be descriptive about what kinds of strings are expected.
+# This retains the flexibility of str, avoiding the need for awkward casting.
+PlatformSubdirStr: TypeAlias = str
+PackageNameStr: TypeAlias = str
+
+
+class HashableFakePackage(TypedDict):
+    """A dict that represents a fake package when computing the lockfile content hash"""
+
+    name: PackageNameStr
+    version: str
+    build_string: str
+    build_number: int
+    build: str
+    noarch: str
+    depends: List[str]
+    timestamp: int
+    package_type: Optional[str]
+    subdir: PlatformSubdirStr
+
+
+class SerializedDependency(TypedDict):
+    # _BaseDependency fields:
+    name: str
+    manager: Literal["conda", "pip"]
+    category: str
+    extras: List[str]
+    markers: NotRequired[Optional[str]]
+    # Note, markers was added in conda-lock v3
+
+    # VersionedDependency fields:
+    version: NotRequired[str]
+    build: NotRequired[Optional[str]]
+    conda_channel: NotRequired[Optional[str]]
+    hash: NotRequired[Optional[str]]
+
+    # URLDependency fields:
+    url: NotRequired[str]
+    hashes: NotRequired[List[str]]
+
+    # VCSDependency fields:
+    source: NotRequired[str]
+    vcs: NotRequired[str]
+    rev: NotRequired[Optional[str]]
+    subdirectory: NotRequired[Optional[str]]
+
+    # PathDependency fields:
+    path: NotRequired[str]
+    is_directory: NotRequired[bool]
+    # # Also in VCSDependency:
+    # subdirectory: NotRequired[Optional[str]]
+
+
+class RepoMetadataInfo(TypedDict):
+    subdir: PlatformSubdirStr
+
+
+class SubdirMetadata(TypedDict):
+    info: RepoMetadataInfo
+    packages: Dict[PackageNameStr, HashableFakePackage]
+
+
+class EmptyDict(TypedDict):
+    pass
+
+
+HashableVirtualPackageRepresentation: "TypeAlias" = Dict[
+    PlatformSubdirStr, Union[SubdirMetadata, EmptyDict]
+]
+
+
+class SerializedLockspec(TypedDict):
+    channels: List[str]
+    specs: List[SerializedDependency]
+    pip_repositories: NotRequired[List[str]]
+    virtual_package_hash: NotRequired[HashableVirtualPackageRepresentation]

--- a/conda_lock/models/lock_spec.py
+++ b/conda_lock/models/lock_spec.py
@@ -121,9 +121,28 @@ class LockSpecification(BaseModel):
             ]
         if virtual_package_repo is not None:
             vpr_data = virtual_package_repo.all_repodata
+
+            # We don't actually use these values! I'm including them to indicate
+            # what I would have expected from the schema. See the code block
+            # immediately below for the actual values.
+            fallback_noarch: Union[SubdirMetadata, EmptyDict] = {
+                "info": {"subdir": "noarch"},
+                "packages": {},
+            }
+            fallback_platform: Union[SubdirMetadata, EmptyDict] = {
+                "info": {"subdir": platform},
+                "packages": {},
+            }
+
+            # It seems a bit of a schema violation, but the original implementation
+            # did this, so we have to keep it in order to preserve consistency of
+            # the hashes.
+            fallback_noarch = {}
+            fallback_platform = {}
+
             data["virtual_package_hash"] = {
-                "noarch": vpr_data.get("noarch", {}),
-                platform: vpr_data.get(platform, {}),
+                "noarch": vpr_data.get("noarch", fallback_noarch),
+                platform: vpr_data.get(platform, fallback_platform),
             }
         return data
 

--- a/conda_lock/models/lock_spec.py
+++ b/conda_lock/models/lock_spec.py
@@ -108,7 +108,7 @@ class LockSpecification(BaseModel):
             vpr_data = virtual_package_repo.all_repodata
             data["virtual_package_hash"] = {
                 "noarch": vpr_data.get("noarch", {}),
-                **{platform: vpr_data.get(platform, {})},
+                platform: vpr_data.get(platform, {}),
             }
 
         env_spec = json.dumps(data, sort_keys=True)

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -25,6 +25,7 @@ from conda_lock._vendor.cleo.io.null_io import NullIO
 from conda_lock._vendor.cleo.io.outputs.output import Verbosity
 from conda_lock._vendor.cleo.io.outputs.stream_output import StreamOutput
 from conda_lock._vendor.poetry.repositories.http_repository import HTTPRepository
+from conda_lock.content_hash_types import HashableFakePackage
 from conda_lock.interfaces.vendored_poetry import (
     Chooser,
     Config,
@@ -83,7 +84,7 @@ class PlatformEnv(VirtualEnv):
         self,
         *,
         platform: str,
-        platform_virtual_packages: Optional[Dict[str, dict]] = None,
+        platform_virtual_packages: Optional[Dict[str, HashableFakePackage]] = None,
         python_version: Optional[str] = None,
     ):
         super().__init__(path=Path(sys.prefix))
@@ -156,7 +157,7 @@ class PlatformEnv(VirtualEnv):
 
 
 def _extract_glibc_version_from_virtual_packages(
-    platform_virtual_packages: Dict[str, dict],
+    platform_virtual_packages: Dict[str, HashableFakePackage],
 ) -> Optional[Version]:
     """Get the glibc version from the "package" repodata of a chosen platform.
 
@@ -216,7 +217,7 @@ def _glibc_version_from_manylinux_tag(tag: str) -> Version:
 
 
 def _compute_compatible_manylinux_tags(
-    platform_virtual_packages: Optional[Dict[str, dict]],
+    platform_virtual_packages: Optional[Dict[str, HashableFakePackage]],
 ) -> List[str]:
     """Determine the manylinux tags that are compatible with the given platform.
 
@@ -454,7 +455,7 @@ def solve_pypi(
     conda_locked: Dict[str, LockedDependency],
     python_version: str,
     platform: str,
-    platform_virtual_packages: Optional[Dict[str, dict]] = None,
+    platform_virtual_packages: Optional[Dict[str, HashableFakePackage]] = None,
     pip_repositories: Optional[List[PipRepository]] = None,
     allow_pypi_requests: bool = True,
     verbose: bool = False,

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -17,7 +17,6 @@ from conda_lock.src_parser.pyproject_toml import (
     parse_platforms_from_pyproject_toml,
     parse_pyproject_toml,
 )
-from conda_lock.virtual_package import FakeRepoData
 
 
 DEFAULT_PLATFORMS = ["linux-64", "osx-arm64", "osx-64", "win-64"]

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -34,7 +34,7 @@ class FakePackage(BaseModel):
     timestamp: int = DEFAULT_TIME
     package_type: Optional[str] = "virtual_system"
 
-    def to_repodata_entry(self) -> Tuple[str, Dict[str, Any]]:
+    def to_repodata_entry(self, *, subdir: str) -> Tuple[str, Dict[str, Any]]:
         out = self.model_dump()
         if self.build_string:
             build = self.build_string
@@ -42,6 +42,7 @@ class FakePackage(BaseModel):
             build = str(self.build_number)
         out["depends"] = list(out["depends"])
         out["build"] = build
+        out["subdir"] = subdir
         fname = f"{self.name}-{self.version}-{build}.tar.bz2"
         return fname, out
 
@@ -98,8 +99,7 @@ class FakeRepoData(BaseModel):
         for pkg, subdirs in self.packages_by_subdir.items():
             if subdir not in subdirs:
                 continue
-            fname, info_dict = pkg.to_repodata_entry()
-            info_dict["subdir"] = subdir
+            fname, info_dict = pkg.to_repodata_entry(subdir=subdir)
             packages[fname] = info_dict
 
         (self.base_path / subdir).mkdir(exist_ok=True)

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,7 +42,7 @@ shellingham = "<2.0,>=1.5"
 tomli = "<3.0.0,>=2.0.1"
 tomlkit = "<1.0.0,>=0.11.4"
 trove-classifiers = ">=2022.5.19"
-typing_extensions = "*"
+typing_extensions = ">=4.6.1"
 virtualenv = "<21.0.0,>=20.26.6"
 zstandard = ">=0.15"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     'tomli >=2.0.1,<3.0.0 ; python_version <"3.11"',
     # constraint on version comes from poetry
     "tomlkit >=0.11.4,<1.0.0",
-    "typing-extensions",
+    "typing-extensions >=4.6.1",
     # conda dependencies
     "boltons >=23.0.0",
     "charset-normalizer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,6 @@ extend-exclude = ["conda_lock/_vendor"]
 [tool.ruff.lint]
 ignore = [
     "E501",
-    "F401",
     "F403",
     # Disabled during migration to Ruff:
     "A001",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import sys
 import typing
 
 from pathlib import Path
-from typing import Any, Iterable, NamedTuple, NoReturn
+from typing import Any, Iterable, NamedTuple
 
 import docker
 import filelock

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -631,7 +631,7 @@ def test_choose_wheel() -> None:
         use_latest=[],
         pip_locked={},
         conda_locked={
-            "python": LockedDependency.parse_obj(
+            "python": LockedDependency.model_validate(
                 {
                     "name": "python",
                     "version": "3.9.7",

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -1925,7 +1925,9 @@ def test_aggregate_lock_specs():
     assert actual.model_dump(exclude={"sources"}) == expected.model_dump(
         exclude={"sources"}
     )
-    assert actual.content_hash(None) == expected.content_hash(None)
+    assert actual.content_hash(virtual_package_repo=None) == expected.content_hash(
+        virtual_package_repo=None
+    )
 
 
 def test_aggregate_lock_specs_override_version():

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -15,7 +15,18 @@ import uuid
 
 from glob import glob
 from pathlib import Path
-from typing import Any, ContextManager, Dict, List, Literal, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    ContextManager,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 from unittest import mock
 from unittest.mock import MagicMock
 from urllib.parse import urldefrag, urlsplit
@@ -54,6 +65,11 @@ from conda_lock.conda_solver import (
     _get_pkgs_dirs,
     extract_json_object,
     fake_conda_environment,
+)
+from conda_lock.content_hash_types import (
+    HashableFakePackage,
+    PackageNameStr,
+    SubdirMetadata,
 )
 from conda_lock.errors import (
     ChannelAggregationError,
@@ -3229,7 +3245,20 @@ def test_platformenv_linux_platforms():
 
     # Check that we get the default platforms when the virtual packages are nonempty
     # but don't include __glibc
-    platform_virtual_packages = {"x.bz2": {"name": "not_glibc"}}
+    platform_virtual_packages: Dict[PackageNameStr, HashableFakePackage] = {
+        "x.bz2": {
+            "name": "__not_glibc",
+            "version": "1",
+            "subdir": "linux-64",
+            "build": "x86_64",
+            "build_number": 0,
+            "build_string": "x86_64",
+            "noarch": "",
+            "depends": [],
+            "timestamp": 1714857600,
+            "package_type": "virtual_system",
+        }
+    }
     e = PlatformEnv(
         python_version="3.12",
         platform="linux-64",
@@ -3240,7 +3269,10 @@ def test_platformenv_linux_platforms():
     # Check that we get the expected platforms when using the default repodata.
     # (This should include the glibc corresponding to the latest manylinux tag.)
     default_repodata = default_virtual_package_repodata()
-    platform_virtual_packages = default_repodata.all_repodata["linux-64"]["packages"]
+    platform_repodata = default_repodata.all_repodata["linux-64"]
+    assert "packages" in platform_repodata
+    platform_repodata = cast(SubdirMetadata, platform_repodata)
+    platform_virtual_packages = platform_repodata["packages"]
     e = PlatformEnv(
         python_version="3.12",
         platform="linux-64",
@@ -3271,9 +3303,18 @@ def test_platformenv_linux_platforms():
         "manylinux1_x86_64",
         "linux_x86_64",
     ]
-    platform_virtual_packages["__glibc-2.17-0.tar.bz2"] = dict(
-        name="__glibc", version="2.17"
-    )
+    platform_virtual_packages["__glibc-2.17-0.tar.bz2"] = {
+        "name": "__glibc",
+        "version": "2.17",
+        "build_string": "",
+        "build_number": 0,
+        "build": "0",
+        "noarch": "",
+        "depends": [],
+        "timestamp": 1577854800000,
+        "package_type": "virtual_system",
+        "subdir": "linux-64",
+    }
     e = PlatformEnv(
         python_version="3.12",
         platform="linux-64",
@@ -3282,9 +3323,18 @@ def test_platformenv_linux_platforms():
     assert e._platforms == restricted_platforms
 
     # Check that a warning is raised when there are multiple glibc versions
-    platform_virtual_packages["__glibc-2.28-0.tar.bz2"] = dict(
-        name="__glibc", version="2.28"
-    )
+    platform_virtual_packages["__glibc-2.28-0.tar.bz2"] = {
+        "name": "__glibc",
+        "version": "2.28",
+        "build_string": "",
+        "build_number": 0,
+        "build": "0",
+        "noarch": "",
+        "depends": [],
+        "timestamp": 1577854800000,
+        "package_type": "virtual_system",
+        "subdir": "linux-64",
+    }
     with pytest.warns(UserWarning):
         e = PlatformEnv(
             python_version="3.12",


### PR DESCRIPTION
### Description

Performs some very light refactoring and adds type annotations to code for computing `content_hash`.

We explicitly add a preexisting `typing-extensions` version constraint from Pydantic to ensure that the imports we use are available.