### PR TITLE
Convert noisy warning into debug log when PyPI package is missing from mapping

### DIFF
--- a/conda_lock/lookup.py
+++ b/conda_lock/lookup.py
@@ -72,7 +72,7 @@ def pypi_name_to_conda_name(name: str, mapping_url: str) -> str:
         if res is not None:
             return res
 
-    logger.warning(f"Could not find conda name for {cname}. Assuming identity.")
+    logger.debug(f"Could not find conda name for {cname}. Assuming identity.")
     return cname
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes #806.

Convert a mostly-spurious logger warning into a debug-level log message, e.g.

```
WARNING:conda_lock.lookup:Could not find conda name for scipy. Assuming identity.
```

Does not address the broader issue in #807.



<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
