### PR TITLE
Refactor lookup cache test to use multiprocessing instead of threading

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1160,7 +1160,6 @@ def run_lock(
     _conda_exe = determine_conda_executable(
         conda_exe, mamba=mamba, micromamba=micromamba
     )
-    logger.debug(f"Using conda executable: {_conda_exe}")
     version_info = subprocess.check_output(
         [_conda_exe, "--version"], encoding="utf-8"
     ).strip()

--- a/conda_lock/invoke_conda.py
+++ b/conda_lock/invoke_conda.py
@@ -62,6 +62,7 @@ def determine_conda_executable(
             if is_micromamba(candidate):
                 if determine_micromamba_version(str(candidate)) < Version("0.17"):
                     mamba_root_prefix()
+            logger.debug(f"Found conda executable: {candidate}")
             return candidate
     raise RuntimeError("Could not find conda (or compatible) executable")
 

--- a/conda_lock/lookup_cache.py
+++ b/conda_lock/lookup_cache.py
@@ -77,6 +77,33 @@ def cached_download_file(
             )
 
 
+def _is_cached_file_fresh(
+    destination: Path, dont_check_if_newer_than_seconds: float
+) -> bool:
+    """Check if a cached file exists and is fresh enough to use without checking.
+
+    (In this context, "checking" means that later, beyond the scope of this function,
+    we will query the server with an ETag to see if the file has changed or if we
+    get a 304 Not Modified response.)
+
+    A file is "fresh" if its age is positive and less than
+    `dont_check_if_newer_than_seconds`.
+
+    Returns True if the file is fresh, False otherwise.
+    """
+    if destination.is_file():
+        age_seconds = get_age_seconds(destination)
+        if age_seconds is None:
+            raise RuntimeError(f"Error checking age of {destination}")
+        if 0 <= age_seconds < dont_check_if_newer_than_seconds:
+            logger.debug(
+                f"Using cached file {destination} of age {age_seconds}s "
+                f"without checking for updates"
+            )
+            return True
+    return False
+
+
 def _download_to_or_read_from_cache(
     url: str, *, cache: Path, dont_check_if_newer_than_seconds: float
 ) -> bytes:
@@ -93,22 +120,14 @@ def _download_to_or_read_from_cache(
     destination_etag = destination.with_suffix(".etag")
     request_headers = {"User-Agent": "conda-lock"}
     # Return the contents immediately if the file is fresh
-    if destination.is_file():
-        age_seconds = get_age_seconds(destination)
-        if age_seconds is None:
-            raise RuntimeError(f"Error checking age of {destination}")
-        if 0 <= age_seconds < dont_check_if_newer_than_seconds:
-            logger.debug(
-                f"Using cached mapping {destination} of age {age_seconds}s "
-                f"without checking for updates"
-            )
-            return destination.read_bytes()
-        # Add the ETag from the last download, if it exists, to the headers.
-        # The ETag is used to avoid downloading the file if it hasn't changed remotely.
-        # Otherwise, download the file and cache the contents and ETag.
-        if destination_etag.is_file():
-            old_etag = destination_etag.read_text().strip()
-            request_headers["If-None-Match"] = old_etag
+    if _is_cached_file_fresh(destination, dont_check_if_newer_than_seconds):
+        return destination.read_bytes()
+    # Add the ETag from the last download, if it exists, to the headers.
+    # The ETag is used to avoid downloading the file if it hasn't changed remotely.
+    # Otherwise, download the file and cache the contents and ETag.
+    if destination.is_file() and destination_etag.is_file():
+        old_etag = destination_etag.read_text().strip()
+        request_headers["If-None-Match"] = old_etag
     # Download the file and cache the result.
     logger.debug(f"Requesting {url}")
     res = requests.get(url, headers=request_headers)

--- a/conda_lock/lookup_cache.py
+++ b/conda_lock/lookup_cache.py
@@ -57,14 +57,17 @@ def cached_download_file(
     cache.mkdir(parents=True, exist_ok=True)
     clear_old_files_from_cache(cache, max_age_seconds=max_age_seconds)
 
-    destination_lock = (cache / cached_filename_for_url(url)).with_suffix(".lock")
+    destination = cache / cached_filename_for_url(url)
+    destination_lock = destination.with_suffix(".lock")
 
     # Wait for any other process to finish downloading the file.
     # This way we can use the result from the current download without
     # spawning multiple concurrent downloads.
     while True:
         try:
+            logger.debug(f"Attempting to acquire lock on {destination_lock}")
             with FileLock(str(destination_lock), timeout=5):
+                logger.debug(f"Successfully acquired lock on {destination_lock}")
                 return _download_to_or_read_from_cache(
                     url,
                     cache=cache,

--- a/tests/test_lookup_cache.py
+++ b/tests/test_lookup_cache.py
@@ -256,7 +256,7 @@ def test_concurrent_cached_download_file(tmp_path):
 
     # Use multiprocessing Manager to share state between processes
     with multiprocessing.Manager() as manager:
-        results: multiprocessing.Queue[bytes] = multiprocessing.Queue()
+        results = manager.Queue()
         process_names_emitting_lock_warnings = manager.list()
         process_names_calling_requests_get = manager.list()
         request_count = manager.Value("i", 0)


### PR DESCRIPTION
I occasionally observe some odd failures of the lookup cache test, already detailed in https://github.com/conda/conda-lock/issues/786. As far as I can tell, everything is working correctly except for the test. I wonder if the test would be more reliable using multiprocessing in place of multithreading. After all, multiprocessing is the type of concurrency we actually use. (Threads are just simpler than processes, and I thought they would be sufficient.) Let's see if this improves the situation.