### PR TITLE
Resolve sporadic failures of lookup cache test

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 # Default to bash in login mode; key to activating conda environment
 # https://github.com/mamba-org/provision-with-micromamba#IMPORTANT

--- a/tests/test_lookup_cache.py
+++ b/tests/test_lookup_cache.py
@@ -1,9 +1,16 @@
 import multiprocessing
 import os
+import queue
 import random
+import threading
 import time
 
+from contextlib import nullcontext
+from multiprocessing.managers import SyncManager
+from multiprocessing.process import BaseProcess
+from multiprocessing.queues import Queue as mp_Queue
 from pathlib import Path
+from typing import Any, Callable, Literal, Union
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -289,19 +296,50 @@ def test_download_mapping_file(tmp_path):
         assert result == result2 == result3
 
 
-def test_concurrent_cached_download_file(tmp_path):
-    """Test concurrent access to cached_download_file with 5 processes."""
+@pytest.mark.parametrize("concurrency_method", ["multiprocessing", "multithreading"])
+def test_concurrent_cached_download_file(
+    tmp_path: Path, concurrency_method: Literal["multiprocessing", "multithreading"]
+):
+    """Test concurrent access to cached_download_file with 5 processes/threads."""
     url = "https://example.com/test.json"
 
-    # Use multiprocessing Manager to share state between processes
-    manager_context = multiprocessing.Manager()
-    results = manager_context.Queue()
-    worker_names_emitting_lock_warnings = manager_context.Queue()
-    worker_names_calling_requests_get = manager_context.Queue()
-    request_count = manager_context.Value("i", 0)
-    current_worker_func = multiprocessing.current_process
-    Worker = multiprocessing.Process
-    worker_name_prefix = "CachedDownloadFileProcess"
+    # Simple counter object for threading
+    class Counter:
+        def __init__(self):
+            self.value = 0
+
+    manager_context: Union[SyncManager, nullcontext[Any]]
+    results: Union[mp_Queue[bytes], queue.Queue[bytes]]
+    worker_names_emitting_lock_warnings: Union[mp_Queue[str], queue.Queue[str]]
+    worker_names_calling_requests_get: Union[mp_Queue[str], queue.Queue[str]]
+    request_count: Any
+    current_worker_func: Union[
+        Callable[[], BaseProcess], Callable[[], threading.Thread]
+    ]
+    Worker: Union[type[multiprocessing.Process], type[threading.Thread]]
+    worker_name_prefix: str
+
+    if concurrency_method == "multiprocessing":
+        # Use multiprocessing Manager to share state between processes
+        manager_context = multiprocessing.Manager()
+        results = manager_context.Queue()
+        worker_names_emitting_lock_warnings = manager_context.Queue()
+        worker_names_calling_requests_get = manager_context.Queue()
+        request_count = manager_context.Value("i", 0)
+        current_worker_func = multiprocessing.current_process
+        Worker = multiprocessing.Process
+        worker_name_prefix = "CachedDownloadFileProcess"
+    elif concurrency_method == "multithreading":
+        manager_context = nullcontext()
+        results = queue.Queue()
+        worker_names_emitting_lock_warnings = queue.Queue()
+        worker_names_calling_requests_get = queue.Queue()
+        request_count = Counter()
+        current_worker_func = threading.current_thread
+        Worker = threading.Thread
+        worker_name_prefix = "CachedDownloadFileThread"
+    else:
+        raise ValueError(f"Invalid concurrency method: {concurrency_method}")
 
     with manager_context:
         # Create and start 5 workers

--- a/tests/test_lookup_cache.py
+++ b/tests/test_lookup_cache.py
@@ -24,7 +24,7 @@ from conda_lock.lookup_cache import (
 )
 
 
-NUM_WORKERS_IN_CONCURRENT_TEST = 5
+NUM_WORKERS_IN_CONCURRENT_TEST = 30
 
 
 def _concurrent_download_worker(

--- a/tests/test_lookup_cache.py
+++ b/tests/test_lookup_cache.py
@@ -122,11 +122,11 @@ def test_clear_old_files_from_cache(mock_cache_dir):
     assert not future_file.exists()
 
     # Immediately rerunning it again should not change anything
-    clear_old_files_from_cache(mock_cache_dir, max_age_seconds=22)
+    clear_old_files_from_cache(mock_cache_dir, max_age_seconds=25)
     assert recent_file.exists()
 
     # Lowering the max age should remove the file
-    clear_old_files_from_cache(mock_cache_dir, max_age_seconds=20)
+    clear_old_files_from_cache(mock_cache_dir, max_age_seconds=15)
     assert not recent_file.exists()
 
 

--- a/tests/test_lookup_cache.py
+++ b/tests/test_lookup_cache.py
@@ -40,7 +40,12 @@ def _concurrent_download_worker(
         request_url = args[0] if args else kwargs.get("url")
         # Only mock the expected URL used by this worker; delegate all other URLs
         if request_url == url:
-            time.sleep(6)
+            # Workers start after 0-100 ms jitter
+            # Timeout occurs after 5 seconds
+            # Sleep of 9 should ensure all workers not grabbing the lock
+            # will actually time out. Sometimes it takes a while for subprocesses
+            # to start, so we offer a generous buffer on top of the 5 seconds.
+            time.sleep(9)
             response = MagicMock()
             response.content = b"content"
             response.status_code = 200

--- a/tests/test_lookup_cache.py
+++ b/tests/test_lookup_cache.py
@@ -392,23 +392,29 @@ def test_concurrent_cached_download_file(
             )
 
         # We expect one worker to have made the request and the other four
-        # to have emitted warnings.
+        # to have emitted timeout warnings.
         status_message = (
             f"{worker_names_calling_requests_get_list=}, "
             f"{worker_names_emitting_lock_warnings_list=}, {request_count.value=}"
         )
+
+        # One and only one worker should have called requests.get
         assert (
             len(worker_names_calling_requests_get_list)
             == 1
             == len(set(worker_names_calling_requests_get_list))
             == request_count.value
         ), status_message
+
+        # Four workers should have emitted timeout warnings
         assert (
             len(worker_names_emitting_lock_warnings_list)
             == 4
             == len(set(worker_names_emitting_lock_warnings_list))
         ), status_message
+
+        # The 4 + 1 workers should be disjoint, making up the total of 5 workers.
         assert set(worker_names) == set(
             worker_names_calling_requests_get_list
             + worker_names_emitting_lock_warnings_list
-        )
+        ), status_message

--- a/tests/test_lookup_cache.py
+++ b/tests/test_lookup_cache.py
@@ -393,17 +393,21 @@ def test_concurrent_cached_download_file(
 
         # We expect one worker to have made the request and the other four
         # to have emitted warnings.
+        status_message = (
+            f"{worker_names_calling_requests_get_list=}, "
+            f"{worker_names_emitting_lock_warnings_list=}, {request_count.value=}"
+        )
         assert (
             len(worker_names_calling_requests_get_list)
             == 1
             == len(set(worker_names_calling_requests_get_list))
             == request_count.value
-        ), f"{worker_names_calling_requests_get_list=}"
+        ), status_message
         assert (
             len(worker_names_emitting_lock_warnings_list)
             == 4
             == len(set(worker_names_emitting_lock_warnings_list))
-        ), f"{worker_names_emitting_lock_warnings_list=}"
+        ), status_message
         assert set(worker_names) == set(
             worker_names_calling_requests_get_list
             + worker_names_emitting_lock_warnings_list


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

We have been haunted by sporadic failures of the lookup cache test.

I believe there may have been one, the other, or a combination of:
* negative ages due to limited resolution of a file's modification time
* delays in spinning up processes leading to the expected timeout not triggering

This PR reworks the tests to include:
* isolation to only the test URL during the monkeypatching requests.get so unrelated concurrent requests.get calls can succeed
* more thorough diagnostic information
* increased simulated download delay by several seconds to allow more time for timeouts to occur for delayed worker processes
* OS-specific decreases in the number of multiprocess workers to mitigate 

It also changes the underlying lookup logic to include:
* a threshold for all operating systems to convert small negative file ages to zero

I'm not totally sure, but I'm fairly hopeful that this entirely resolves the sporadic failures we've been seeing.
