### PR TITLE
[feature] support allow-pypi-requests in environment yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ The location of this file can be determined with `python -c 'from conda_lock._ve
 
 Private repositories will be used in addition to `pypi.org`. For projects using `pyproject.toml`, it is possible to [disable `pypi.org` entirely](#disabling-pypiorg).
 
+#### Disabling pypi.org
+
+When using private pip repos, it is possible to disable `pypi.org` entirely in your `environment.yml` file.
+This can be useful when using `conda-lock` behind a network proxy that does not allow access to `pypi.org`.
+
+```yaml
+channels:
+  - conda-forge
+allow-pypi-requests: false
+pip-repositories:
+  - http://$PIP_USER:$PIP_PASSWORD@private-pypi.org/api/pypi/simple
+dependencies:
+  - python=3.11
+  - requests=2.26
+  - pip:
+    - fake-private-package==1.0.0
+```
+
 ### --dev-dependencies/--no-dev-dependencies
 
 By default conda-lock will include dev dependencies in the specification of the lock (if the files that the lock

--- a/conda_lock/src_parser/environment_yaml.py
+++ b/conda_lock/src_parser/environment_yaml.py
@@ -131,6 +131,7 @@ def parse_environment_file(
         pass
 
     pip_repositories: list[str] = env_yaml_data.get("pip-repositories", [])
+    allow_pypi_requests: bool = env_yaml_data.get("allow-pypi-requests", True)
 
     # These extension fields are nonstandard
     category: str = env_yaml_data.get("category") or "main"
@@ -148,4 +149,5 @@ def parse_environment_file(
         channels=channels,  # type: ignore
         pip_repositories=pip_repositories,  # type: ignore
         sources=[environment_file],
+        allow_pypi_requests=allow_pypi_requests,
     )

--- a/tests/test-env-yaml-allow-pypi-requests/env.explicit.yml
+++ b/tests/test-env-yaml-allow-pypi-requests/env.explicit.yml
@@ -1,0 +1,13 @@
+name: allow-pypi
+
+allow-pypi-requests: true
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+    - requests
+

--- a/tests/test-env-yaml-allow-pypi-requests/env.implicit.yml
+++ b/tests/test-env-yaml-allow-pypi-requests/env.implicit.yml
@@ -1,0 +1,11 @@
+name: allow-pypi
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+    - requests
+

--- a/tests/test-env-yaml-allow-pypi-requests/env.no-pypi-requests.yml
+++ b/tests/test-env-yaml-allow-pypi-requests/env.no-pypi-requests.yml
@@ -1,0 +1,13 @@
+name: no-allow-pypi
+
+allow-pypi-requests: false
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+    - requests
+

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -223,6 +223,11 @@ def blas_mkl_environment(tmp_path: Path):
 
 
 @pytest.fixture
+def env_yaml_allow_pypi_requests(tmp_path: Path):
+    return clone_test_dir("test-env-yaml-allow-pypi-requests", tmp_path)
+
+
+@pytest.fixture
 def meta_yaml_environment(tmp_path: Path):
     return clone_test_dir("test-recipe", tmp_path).joinpath("meta.yaml")
 
@@ -491,6 +496,31 @@ def test_parse_environment_file_with_pip(pip_environment: Path):
                 version="==0.9.1",
             )
         ]
+
+
+def test_parse_environment_file_allow_pypi_requests(env_yaml_allow_pypi_requests: Path):
+    implicit = env_yaml_allow_pypi_requests / "env.implicit.yml"
+    implicit_spec = parse_environment_file(
+        implicit, platforms=DEFAULT_PLATFORMS, mapping_url=DEFAULT_MAPPING_URL
+    )
+    assert implicit_spec.allow_pypi_requests
+
+    explicit = env_yaml_allow_pypi_requests / "env.explicit.yml"
+    explicit_spec = parse_environment_file(
+        explicit, platforms=DEFAULT_PLATFORMS, mapping_url=DEFAULT_MAPPING_URL
+    )
+    assert explicit_spec.allow_pypi_requests
+
+    no_pypi = env_yaml_allow_pypi_requests / "env.no-pypi-requests.yml"
+    no_pypi_spec = parse_environment_file(
+        no_pypi, platforms=DEFAULT_PLATFORMS, mapping_url=DEFAULT_MAPPING_URL
+    )
+    assert not no_pypi_spec.allow_pypi_requests
+
+    agg = aggregate_lock_specs(
+        lock_specs=[implicit_spec, no_pypi_spec], platforms=DEFAULT_PLATFORMS
+    )
+    assert not agg.allow_pypi_requests
 
 
 def test_parse_environment_file_with_git(git_environment: Path):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Here I've added support for `allow-pypi-requests:` in environment.yaml sources

```yaml
channels:
  - conda-forge
allow-pypi-requests: false
pip-repositories:
  - http://$PIP_USER:$PIP_PASSWORD@private-pypi.org/api/pypi/simple
dependencies:
  - python=3.11
  - requests=2.26
  - pip:
    - fake-private-package==1.0.0
```