### PR TITLE
Add 2.18 as a valid glibc version

### DIFF
--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 # in practice, see https://github.com/pypa/manylinux/blob/main/README.rst#docker-images.
 # NOTE:
 #   Keep the max in sync with the default value used in default-virtual-packages.yaml.
-MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17", "_2_24", "_2_28"]
+MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17", "_2_18", "_2_24", "_2_28"]
 
 # This needs to be updated periodically as new macOS versions are released.
 MACOS_VERSION = (13, 4)

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -241,7 +241,7 @@ def _compute_compatible_manylinux_tags(
     >>> _compute_compatible_manylinux_tags({}) == list(reversed(MANYLINUX_TAGS))
     True
     >>> _compute_compatible_manylinux_tags(platform_virtual_packages)
-    ['_2_24', '_2_17', '2014', '2010', '1']
+    ['_2_24', '_2_18', '_2_17', '2014', '2010', '1']
     """
     # We use MANYLINUX_TAGS but only go up to the latest supported version
     # as provided by __glibc if present


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Some packages like `nvidia-nccl-cu12` list 2.18 as their minimum GLIBC version. Conda-lock would only add 2.17 (which is more standard I guess) causing resolution to fail.

An example failing environment is the following:

```
channels:
  - conda-forge
dependencies:
  - numpy <=2
  - pip:
    - xgboost >=2
```

`xgboost` indirectly uses `nvidia-nccl-cu-12` which fails. This tiny patch just adds 2.18 as a GLIBC option if supported and makes the above environment properly resolvable.