### PR TITLE
fix(pypi): preserve real version for URL-pinned pip deps on re-lock

### DIFF
--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -351,7 +351,7 @@ def get_package(locked: LockedDependency) -> PoetryPackage:
             locked.name,
             source_type="url",
             source_url=locked.source.url,
-            version="0.0.0",
+            version=locked.version,
         )
     else:
         return PoetryPackage(locked.name, version=locked.version)

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -78,6 +78,7 @@ from conda_lock.interfaces.vendored_conda import MatchSpec
 from conda_lock.invoke_conda import is_micromamba, reset_conda_pkgs_dir
 from conda_lock.lockfile import parse_conda_lock_file
 from conda_lock.lockfile.v2prelim.models import (
+    DependencySource,
     HashModel,
     LockedDependency,
     MetadataOption,
@@ -94,6 +95,7 @@ from conda_lock.pypi_solver import (
     MANYLINUX_TAGS,
     PlatformEnv,
     _strip_auth,
+    get_package,
     parse_pip_requirement,
     solve_pypi,
 )
@@ -3478,6 +3480,28 @@ def test_pip_full_whl_url(
         typing_extensions_dep.hash.sha256
         == "8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"
     )
+
+
+def test_get_package_preserves_version_for_url_source():
+    """A URL-sourced locked dep must reconcile with its real version, not a 0.0.0 placeholder."""
+    url = "https://example.com/foo-1.2.3-py3-none-any.whl"
+    locked = LockedDependency(
+        name="foo",
+        version="1.2.3",
+        manager="pip",
+        platform="linux-64",
+        dependencies={},
+        url=url,
+        hash=HashModel(),
+        source=DependencySource(type="url", url=url),
+    )
+
+    package = get_package(locked)
+
+    assert str(package.version) == "1.2.3"
+    # The dependency stays URL-pinned.
+    assert package.source_type == "url"
+    assert package.source_url == url
 
 
 def test_when_merging_lockfiles_content_hashes_are_updated(


### PR DESCRIPTION
## Description

Fixes #922.

`get_package` reconstructs a Poetry package from an already-locked dependency during a re-lock (the
reconcile solve). For URL-sourced deps it hard-coded `version="0.0.0"`, discarding the real version
stored in `locked.version`.

That placeholder breaks the reconcile whenever another package constrains the URL-pinned dep by
version (e.g. a transitive `foo >=1.0`): the solver either silently downgrades the constraining
packages to ancient versions (and emits the URL dep as `0.0.0`), or fails outright with a
`SolverProblemError` when no downgrade is possible. A first-time lock is unaffected (the URL dep is
resolved fresh); only reconciliation (`--update`, or a changed input under `--check-input-hash`)
hits it.

This uses `locked.version` — matching the non-URL `else` branch in the same function — while
leaving the URL pin (`source_type`/`source_url`) intact. A `LockedDependency`'s `source` is always a
URL source (`DependencySource.type` is `Literal["url"]`), so no source-type gating is needed.

*(Prepared with AI assistance.)* 🤖

## Change — `conda_lock/pypi_solver.py`

```diff
 def get_package(locked: LockedDependency) -> PoetryPackage:
     if locked.source is not None:
         return PoetryPackage(
             locked.name,
             source_type="url",
             source_url=locked.source.url,
-            version="0.0.0",
+            version=locked.version,
         )
     else:
         return PoetryPackage(locked.name, version=locked.version)
```

## Test — `tests/test_conda_lock.py`

A deterministic, network-free regression test pinning the defect (fails pre-fix with `0.0.0`,
passes post-fix), asserting both the version and the preserved URL pin:

```python
def test_get_package_preserves_version_for_url_source():
    """A URL-sourced locked dep must reconcile with its real version, not a 0.0.0 placeholder."""
    url = "https://example.com/foo-1.2.3-py3-none-any.whl"
    locked = LockedDependency(
        name="foo",
        version="1.2.3",
        manager="pip",
        platform="linux-64",
        dependencies={},
        url=url,
        hash=HashModel(),
        source=DependencySource(type="url", url=url),
    )

    package = get_package(locked)

    assert str(package.version) == "1.2.3"
    # The dependency stays URL-pinned.
    assert package.source_type == "url"
    assert package.source_url == url
```

## Notes for maintainers

- The end-to-end consequence (reconcile corruption / `SolverProblemError`) needs a graph with a
  transitive version constraint on the URL-pinned dep; the minimal case is `idna @ <url>` +
  `requests`, locked then re-locked. I kept the committed regression test at the unit level (no
  network, deterministic) since that's the smallest reliable gate; happy to add an integration
  fixture if you'd prefer one.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
