### PR TITLE
Use target virtual packages during conda solves

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -793,15 +793,16 @@ def _solve_for_arch(
         for manager in ("conda", "pip")
     }
 
-    conda_deps = solve_conda(
-        conda,
-        specs=requested_deps_by_name["conda"],
-        locked=locked_deps_by_name["conda"],
-        update=update_spec.update,
-        platform=platform,
-        channels=channels,
-        mapping_url=mapping_url,
-    )
+    with virtual_package_repo.conda_virtual_package_overrides(platform):
+        conda_deps = solve_conda(
+            conda,
+            specs=requested_deps_by_name["conda"],
+            locked=locked_deps_by_name["conda"],
+            update=update_spec.update,
+            platform=platform,
+            channels=channels,
+            mapping_url=mapping_url,
+        )
 
     if requested_deps_by_name["pip"]:
         if "python" not in conda_deps:

--- a/conda_lock/interfaces/vendored_conda.py
+++ b/conda_lock/interfaces/vendored_conda.py
@@ -4,6 +4,13 @@ from conda_lock._vendor.conda.common.url import (
     split_anaconda_token,
 )
 from conda_lock._vendor.conda.models.match_spec import MatchSpec
+from conda_lock._vendor.conda.models.version import VersionOrder
 
 
-__all__ = ["MatchSpec", "mask_anaconda_token", "split_anaconda_token", "toposort"]
+__all__ = [
+    "MatchSpec",
+    "VersionOrder",
+    "mask_anaconda_token",
+    "split_anaconda_token",
+    "toposort",
+]

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -205,7 +205,9 @@ class FakeRepoData(BaseModel):
     ) -> Iterator[None]:
         """Temporarily match solver overrides to the target's fake repodata."""
         packages: dict[str, FullVirtualPackage] = {}
-        overrides: dict[str, str] = {}
+        overrides = {
+            name: "" for name in os.environ if name.startswith("CONDA_OVERRIDE_")
+        }
         for package, subdirs in self.packages_by_subdir.items():
             if not package.name.startswith("__"):
                 continue

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -32,6 +32,15 @@ logger = logging.getLogger(__name__)
 # datetime.datetime(2020, 1, 1).timestamp()
 DEFAULT_TIME = 1577854800000
 
+CONDA_VIRTUAL_PACKAGE_OVERRIDES = {
+    "CONDA_OVERRIDE_ARCHSPEC",
+    "CONDA_OVERRIDE_CUDA",
+    "CONDA_OVERRIDE_GLIBC",
+    "CONDA_OVERRIDE_LINUX",
+    "CONDA_OVERRIDE_OSX",
+    "CONDA_OVERRIDE_WIN",
+}
+
 VirtualPackageVersion: TypeAlias = str
 
 
@@ -205,9 +214,11 @@ class FakeRepoData(BaseModel):
     ) -> Iterator[None]:
         """Temporarily match solver overrides to the target's fake repodata."""
         packages: dict[str, FullVirtualPackage] = {}
-        overrides = {
-            name: "" for name in os.environ if name.startswith("CONDA_OVERRIDE_")
-        }
+        overrides = dict.fromkeys(
+            CONDA_VIRTUAL_PACKAGE_OVERRIDES
+            | {name for name in os.environ if name.startswith("CONDA_OVERRIDE_")},
+            "",
+        )
         for package, subdirs in self.packages_by_subdir.items():
             if not package.name.startswith("__"):
                 continue

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -4,7 +4,8 @@ import os
 import pathlib
 
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from importlib.resources import path
 from types import TracebackType
 from typing import (
@@ -21,6 +22,7 @@ from conda_lock.content_hash_types import (
     PlatformSubdirStr,
     SubdirMetadata,
 )
+from conda_lock.interfaces.vendored_conda import VersionOrder
 from conda_lock.models.channel import Channel
 from conda_lock.tempdir_manager import mkdtemp_with_cleanup
 
@@ -196,6 +198,44 @@ class FakeRepoData(BaseModel):
                 del os.environ[k]
             else:
                 os.environ[k] = v
+
+    @contextmanager
+    def conda_virtual_package_overrides(
+        self, platform: PlatformSubdirStr
+    ) -> Iterator[None]:
+        """Temporarily match solver overrides to the target's fake repodata."""
+        packages: dict[str, FullVirtualPackage] = {}
+        overrides: dict[str, str] = {}
+        for package, subdirs in self.packages_by_subdir.items():
+            if not package.name.startswith("__"):
+                continue
+
+            env_var = f"CONDA_OVERRIDE_{package.name.lstrip('_').upper()}"
+            overrides[env_var] = ""
+            current = packages.get(env_var)
+            if platform in subdirs and (
+                current is None
+                or VersionOrder(package.version) > VersionOrder(current.version)
+            ):
+                packages[env_var] = package
+
+        for env_var, package in packages.items():
+            overrides[env_var] = (
+                package.build_string
+                if package.name == "__archspec"
+                else package.version
+            )
+
+        old_env_vars = {name: os.environ.get(name) for name in overrides}
+        os.environ.update(overrides)
+        try:
+            yield
+        finally:
+            for name, value in old_env_vars.items():
+                if value is None:
+                    del os.environ[name]
+                else:
+                    os.environ[name] = value
 
 
 def _init_fake_repodata() -> FakeRepoData:

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2858,8 +2858,9 @@ def test_solve_uses_target_virtual_package_overrides(
     )
 
 
+@pytest.mark.parametrize("cuda_override", [None, "host-value"])
 def test_solve_clears_unconfigured_virtual_package_override(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, cuda_override: str | None
 ) -> None:
     from conda_lock.virtual_package import virtual_package_repo_from_specification
 
@@ -2871,7 +2872,10 @@ def test_solve_clears_unconfigured_virtual_package_override(
         return {}
 
     monkeypatch.setattr("conda_lock.conda_lock.solve_conda", solve_conda)
-    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "host-value")
+    if cuda_override is None:
+        monkeypatch.delenv("CONDA_OVERRIDE_CUDA", raising=False)
+    else:
+        monkeypatch.setenv("CONDA_OVERRIDE_CUDA", cuda_override)
     virtual_package_repo = virtual_package_repo_from_specification(
         TESTS_DIR / "test-archspec" / "virtual-packages.yaml"
     )
@@ -2889,7 +2893,7 @@ def test_solve_clears_unconfigured_virtual_package_override(
         )
 
     assert actual_cuda_override == ""
-    assert os.environ["CONDA_OVERRIDE_CUDA"] == "host-value"
+    assert os.environ.get("CONDA_OVERRIDE_CUDA") == cuda_override
 
 
 def test_default_virtual_package_input_hash_stability():

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2858,6 +2858,40 @@ def test_solve_uses_target_virtual_package_overrides(
     )
 
 
+def test_solve_clears_unconfigured_virtual_package_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from conda_lock.virtual_package import virtual_package_repo_from_specification
+
+    actual_cuda_override = None
+
+    def solve_conda(*args: Any, **kwargs: Any) -> dict[str, LockedDependency]:
+        nonlocal actual_cuda_override
+        actual_cuda_override = os.environ.get("CONDA_OVERRIDE_CUDA")
+        return {}
+
+    monkeypatch.setattr("conda_lock.conda_lock.solve_conda", solve_conda)
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "host-value")
+    virtual_package_repo = virtual_package_repo_from_specification(
+        TESTS_DIR / "test-archspec" / "virtual-packages.yaml"
+    )
+    spec = LockSpecification(dependencies={"linux-64": []}, channels=[], sources=[])
+
+    with virtual_package_repo:
+        _solve_for_arch(
+            conda="micromamba",
+            spec=spec,
+            platform="linux-64",
+            channels=[],
+            pip_repositories=[],
+            virtual_package_repo=virtual_package_repo,
+            mapping_url=DEFAULT_MAPPING_URL,
+        )
+
+    assert actual_cuda_override == ""
+    assert os.environ["CONDA_OVERRIDE_CUDA"] == "host-value"
+
+
 def test_default_virtual_package_input_hash_stability():
     from conda_lock.virtual_package import default_virtual_package_repodata
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2806,6 +2806,58 @@ def test_virtual_package_input_hash_stability():
     assert compute_content_hashes(spec, vpr) == {"linux-64": expected}
 
 
+@pytest.mark.parametrize(
+    ("platform", "expected_archspec"),
+    [("osx-64", "x86_64"), ("osx-arm64", "arm64")],
+)
+def test_solve_uses_target_virtual_package_overrides(
+    monkeypatch: pytest.MonkeyPatch, platform: str, expected_archspec: str
+) -> None:
+    override_names = {
+        "CONDA_OVERRIDE_ARCHSPEC",
+        "CONDA_OVERRIDE_CUDA",
+        "CONDA_OVERRIDE_GLIBC",
+        "CONDA_OVERRIDE_LINUX",
+        "CONDA_OVERRIDE_OSX",
+        "CONDA_OVERRIDE_WIN",
+    }
+    for name in override_names:
+        monkeypatch.setenv(name, "host-value")
+
+    actual_overrides: dict[str, str | None] = {}
+
+    def solve_conda(*args: Any, **kwargs: Any) -> dict[str, LockedDependency]:
+        actual_overrides.update({name: os.environ.get(name) for name in override_names})
+        return {}
+
+    monkeypatch.setattr("conda_lock.conda_lock.solve_conda", solve_conda)
+    spec = LockSpecification(dependencies={platform: []}, channels=[], sources=[])
+    virtual_package_repo = default_virtual_package_repodata()
+
+    with virtual_package_repo:
+        _solve_for_arch(
+            conda="micromamba",
+            spec=spec,
+            platform=platform,
+            channels=[],
+            pip_repositories=[],
+            virtual_package_repo=virtual_package_repo,
+            mapping_url=DEFAULT_MAPPING_URL,
+        )
+
+    assert actual_overrides == {
+        "CONDA_OVERRIDE_ARCHSPEC": expected_archspec,
+        "CONDA_OVERRIDE_CUDA": "",
+        "CONDA_OVERRIDE_GLIBC": "",
+        "CONDA_OVERRIDE_LINUX": "",
+        "CONDA_OVERRIDE_OSX": "11.0",
+        "CONDA_OVERRIDE_WIN": "",
+    }
+    assert {name: os.environ[name] for name in override_names} == dict.fromkeys(
+        override_names, "host-value"
+    )
+
+
 def test_default_virtual_package_input_hash_stability():
     from conda_lock.virtual_package import default_virtual_package_repodata
 


### PR DESCRIPTION
When conda-lock solves for a platform other than the host, the solver's detected virtual packages can disagree with the target virtual-package repository.

This makes the override environment match the target platform for each conda solve and restores it afterwards. It also clears overrides that are not configured for the target and adds coverage for custom virtual-package specs.

The behavior reproduces with micromamba 2.9.0. The same solve succeeds with micromamba 2.4.0.