### PR TITLE
ci: add workflow concurrency limits

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -17,11 +17,14 @@ permissions: {}
 env:
   MICROMAMBA_VERSION: 'latest'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
-    concurrency: ci-${{ github.ref }}
     permissions:
       contents: write  # for mkdocs gh-deploy to push to gh-pages branch
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
   push:
     branches: [master, main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Add workflow-level concurrency to documentation and zizmor runs. Group release workflows by tag or ref and keep release cancellation disabled.

Part of conda/infrastructure#706

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex